### PR TITLE
Fix (#30): Fix race-condition in parser-libraries while compiling

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -9,7 +9,7 @@ PARENT_DIR="$(dirname "$DIR")"
 
 # IMPORTNANT: at the moment it has to be build with only 1 thread, because the parser-generation with bison and flex
 #             has problems in a parallel build-process (see issue #30)
-/usr/bin/make -j1
+/usr/bin/make -j8
 
 #-----------------------------------------------------------------------------------------------------------------
 

--- a/src/libraries/libKitsunemimiHanamiClusterParser/libKitsunemimiHanamiClusterParser.pro
+++ b/src/libraries/libKitsunemimiHanamiClusterParser/libKitsunemimiHanamiClusterParser.pro
@@ -3,7 +3,15 @@ CONFIG += ordered
 QT -= qt core gui
 CONFIG += c++17
 
-SUBDIRS = src
+lexxer.file = src/lexxer.pro
+parser.file = src/parser.pro
+
+SUBDIRS = parser
+SUBDIRS += lexxer
+SUBDIRS += src
+
+lexxer.depends = parser
+src.depends = lexxer
 
 run_tests {
     SUBDIRS += tests

--- a/src/libraries/libKitsunemimiHanamiClusterParser/src/lexxer.pro
+++ b/src/libraries/libKitsunemimiHanamiClusterParser/src/lexxer.pro
@@ -1,0 +1,41 @@
+QT -= qt core gui
+TEMPLATE = aux
+CONFIG += c++17 staticlib
+
+LIBS += -L../../libKitsunemimiCommon/src -lKitsunemimiCommon
+LIBS += -L../../libKitsunemimiCommon/src/debug -lKitsunemimiCommon
+LIBS += -L../../libKitsunemimiCommon/src/release -lKitsunemimiCommon
+INCLUDEPATH += ../../libKitsunemimiCommon/include
+
+LIBS += -L../../libKitsunemimiHanamiCommon/src -lKitsunemimiHanamiCommon
+LIBS += -L../../libKitsunemimiHanamiCommon/src/debug -lKitsunemimiHanamiCommon
+LIBS += -L../../libKitsunemimiHanamiCommon/src/release -lKitsunemimiHanamiCommon
+INCLUDEPATH += ../../libKitsunemimiHanamiCommon/include
+
+INCLUDEPATH += $$PWD \
+               $$PWD/../include
+
+FLEXSOURCES = grammar/cluster_lexer.l
+
+OTHER_FILES +=  \
+    $$FLEXSOURCES 
+
+# The following code calls the flex-lexer and bison-parser before compiling the
+# cpp-code for automatic generation of the parser-code in each build-step.
+# The resulting source-code-files are stored in the build-directory of the json-converter.
+flexsource.input = FLEXSOURCES
+flexsource.output = ${QMAKE_FILE_BASE}.cpp
+flexsource.commands = flex --header-file=${QMAKE_FILE_BASE}.h -o ${QMAKE_FILE_BASE}.cpp ${QMAKE_FILE_IN}
+flexsource.variable_out = SOURCES
+flexsource.name = Flex Sources ${QMAKE_FILE_IN}
+
+QMAKE_EXTRA_COMPILERS += flexsource
+
+flexheader.input = FLEXSOURCES
+flexheader.output = ${QMAKE_FILE_BASE}.h
+flexheader.commands = @true
+flexheader.variable_out = HEADERS
+flexheader.name = Flex Headers ${QMAKE_FILE_IN}
+flexheader.CONFIG = no_link
+
+QMAKE_EXTRA_COMPILERS += flexheader

--- a/src/libraries/libKitsunemimiHanamiClusterParser/src/parser.pro
+++ b/src/libraries/libKitsunemimiHanamiClusterParser/src/parser.pro
@@ -1,0 +1,38 @@
+QT -= qt core gui
+TEMPLATE = aux
+CONFIG += c++17 staticlib
+
+LIBS += -L../../libKitsunemimiCommon/src -lKitsunemimiCommon
+LIBS += -L../../libKitsunemimiCommon/src/debug -lKitsunemimiCommon
+LIBS += -L../../libKitsunemimiCommon/src/release -lKitsunemimiCommon
+INCLUDEPATH += ../../libKitsunemimiCommon/include
+
+LIBS += -L../../libKitsunemimiHanamiCommon/src -lKitsunemimiHanamiCommon
+LIBS += -L../../libKitsunemimiHanamiCommon/src/debug -lKitsunemimiHanamiCommon
+LIBS += -L../../libKitsunemimiHanamiCommon/src/release -lKitsunemimiHanamiCommon
+INCLUDEPATH += ../../libKitsunemimiHanamiCommon/include
+
+INCLUDEPATH += $$PWD \
+               $$PWD/../include
+
+BISONSOURCES = grammar/cluster_parser.y
+
+OTHER_FILES +=  \
+    $$BISONSOURCES
+
+bisonsource.input = BISONSOURCES
+bisonsource.output = ${QMAKE_FILE_BASE}.cpp
+bisonsource.commands = bison -d --defines=${QMAKE_FILE_BASE}.h -o ${QMAKE_FILE_BASE}.cpp ${QMAKE_FILE_IN}
+bisonsource.variable_out = SOURCES
+bisonsource.name = Bison Sources ${QMAKE_FILE_IN}
+
+QMAKE_EXTRA_COMPILERS += bisonsource
+
+bisonheader.input = BISONSOURCES
+bisonheader.output = ${QMAKE_FILE_BASE}.h
+bisonheader.commands = @true
+bisonheader.variable_out = HEADERS
+bisonheader.name = Bison Headers ${QMAKE_FILE_IN}
+bisonheader.CONFIG =  no_link
+
+QMAKE_EXTRA_COMPILERS += bisonheader

--- a/src/libraries/libKitsunemimiHanamiPolicies/libKitsunemimiHanamiPolicies.pro
+++ b/src/libraries/libKitsunemimiHanamiPolicies/libKitsunemimiHanamiPolicies.pro
@@ -1,7 +1,15 @@
 TEMPLATE = subdirs
 CONFIG += ordered
 
-SUBDIRS = src
+lexxer.file = src/lexxer.pro
+parser.file = src/parser.pro
+
+SUBDIRS = parser
+SUBDIRS += lexxer
+SUBDIRS += src
+
+lexxer.depends = parser
+src.depends = lexxer
 
 run_tests {
     SUBDIRS += tests

--- a/src/libraries/libKitsunemimiHanamiPolicies/src/lexxer.pro
+++ b/src/libraries/libKitsunemimiHanamiPolicies/src/lexxer.pro
@@ -1,0 +1,41 @@
+QT -= qt core gui
+TEMPLATE = aux
+CONFIG += c++17 staticlib
+
+LIBS += -L../../libKitsunemimiCommon/src -lKitsunemimiCommon
+LIBS += -L../../libKitsunemimiCommon/src/debug -lKitsunemimiCommon
+LIBS += -L../../libKitsunemimiCommon/src/release -lKitsunemimiCommon
+INCLUDEPATH += ../../libKitsunemimiCommon/include
+
+LIBS += -L../../libKitsunemimiHanamiCommon/src -lKitsunemimiHanamiCommon
+LIBS += -L../../libKitsunemimiHanamiCommon/src/debug -lKitsunemimiHanamiCommon
+LIBS += -L../../libKitsunemimiHanamiCommon/src/release -lKitsunemimiHanamiCommon
+INCLUDEPATH += ../../libKitsunemimiHanamiCommon/include
+
+INCLUDEPATH += $$PWD \
+               $$PWD/../include
+
+FLEXSOURCES = grammar/policy_lexer.l
+
+OTHER_FILES +=  \
+    $$FLEXSOURCES 
+
+# The following code calls the flex-lexer and bison-parser before compiling the
+# cpp-code for automatic generation of the parser-code in each build-step.
+# The resulting source-code-files are stored in the build-directory of the json-converter.
+flexsource.input = FLEXSOURCES
+flexsource.output = ${QMAKE_FILE_BASE}.cpp
+flexsource.commands = flex --header-file=${QMAKE_FILE_BASE}.h -o ${QMAKE_FILE_BASE}.cpp ${QMAKE_FILE_IN}
+flexsource.variable_out = SOURCES
+flexsource.name = Flex Sources ${QMAKE_FILE_IN}
+
+QMAKE_EXTRA_COMPILERS += flexsource
+
+flexheader.input = FLEXSOURCES
+flexheader.output = ${QMAKE_FILE_BASE}.h
+flexheader.commands = @true
+flexheader.variable_out = HEADERS
+flexheader.name = Flex Headers ${QMAKE_FILE_IN}
+flexheader.CONFIG = no_link
+
+QMAKE_EXTRA_COMPILERS += flexheader

--- a/src/libraries/libKitsunemimiHanamiPolicies/src/parser.pro
+++ b/src/libraries/libKitsunemimiHanamiPolicies/src/parser.pro
@@ -1,0 +1,38 @@
+QT -= qt core gui
+TEMPLATE = aux
+CONFIG += c++17 staticlib
+
+LIBS += -L../../libKitsunemimiCommon/src -lKitsunemimiCommon
+LIBS += -L../../libKitsunemimiCommon/src/debug -lKitsunemimiCommon
+LIBS += -L../../libKitsunemimiCommon/src/release -lKitsunemimiCommon
+INCLUDEPATH += ../../libKitsunemimiCommon/include
+
+LIBS += -L../../libKitsunemimiHanamiCommon/src -lKitsunemimiHanamiCommon
+LIBS += -L../../libKitsunemimiHanamiCommon/src/debug -lKitsunemimiHanamiCommon
+LIBS += -L../../libKitsunemimiHanamiCommon/src/release -lKitsunemimiHanamiCommon
+INCLUDEPATH += ../../libKitsunemimiHanamiCommon/include
+
+INCLUDEPATH += $$PWD \
+               $$PWD/../include
+
+BISONSOURCES = grammar/policy_parser.y
+
+OTHER_FILES +=  \
+    $$BISONSOURCES
+
+bisonsource.input = BISONSOURCES
+bisonsource.output = ${QMAKE_FILE_BASE}.cpp
+bisonsource.commands = bison -d --defines=${QMAKE_FILE_BASE}.h -o ${QMAKE_FILE_BASE}.cpp ${QMAKE_FILE_IN}
+bisonsource.variable_out = SOURCES
+bisonsource.name = Bison Sources ${QMAKE_FILE_IN}
+
+QMAKE_EXTRA_COMPILERS += bisonsource
+
+bisonheader.input = BISONSOURCES
+bisonheader.output = ${QMAKE_FILE_BASE}.h
+bisonheader.commands = @true
+bisonheader.variable_out = HEADERS
+bisonheader.name = Bison Headers ${QMAKE_FILE_IN}
+bisonheader.CONFIG =  no_link
+
+QMAKE_EXTRA_COMPILERS += bisonheader

--- a/src/libraries/libKitsunemimiHanamiSegmentParser/libKitsunemimiHanamiSegmentParser.pro
+++ b/src/libraries/libKitsunemimiHanamiSegmentParser/libKitsunemimiHanamiSegmentParser.pro
@@ -3,7 +3,15 @@ CONFIG += ordered
 QT -= qt core gui
 CONFIG += c++14
 
-SUBDIRS = src
+lexxer.file = src/lexxer.pro
+parser.file = src/parser.pro
+
+SUBDIRS = parser
+SUBDIRS += lexxer
+SUBDIRS += src
+
+lexxer.depends = parser
+src.depends = lexxer
 
 run_tests {
     SUBDIRS += tests

--- a/src/libraries/libKitsunemimiHanamiSegmentParser/src/lexxer.pro
+++ b/src/libraries/libKitsunemimiHanamiSegmentParser/src/lexxer.pro
@@ -1,0 +1,41 @@
+QT -= qt core gui
+TEMPLATE = aux
+CONFIG += c++17 staticlib
+
+LIBS += -L../../libKitsunemimiCommon/src -lKitsunemimiCommon
+LIBS += -L../../libKitsunemimiCommon/src/debug -lKitsunemimiCommon
+LIBS += -L../../libKitsunemimiCommon/src/release -lKitsunemimiCommon
+INCLUDEPATH += ../../libKitsunemimiCommon/include
+
+LIBS += -L../../libKitsunemimiHanamiCommon/src -lKitsunemimiHanamiCommon
+LIBS += -L../../libKitsunemimiHanamiCommon/src/debug -lKitsunemimiHanamiCommon
+LIBS += -L../../libKitsunemimiHanamiCommon/src/release -lKitsunemimiHanamiCommon
+INCLUDEPATH += ../../libKitsunemimiHanamiCommon/include
+
+INCLUDEPATH += $$PWD \
+               $$PWD/../include
+
+FLEXSOURCES = grammar/segment_lexer.l
+
+OTHER_FILES +=  \
+    $$FLEXSOURCES 
+
+# The following code calls the flex-lexer and bison-parser before compiling the
+# cpp-code for automatic generation of the parser-code in each build-step.
+# The resulting source-code-files are stored in the build-directory of the json-converter.
+flexsource.input = FLEXSOURCES
+flexsource.output = ${QMAKE_FILE_BASE}.cpp
+flexsource.commands = flex --header-file=${QMAKE_FILE_BASE}.h -o ${QMAKE_FILE_BASE}.cpp ${QMAKE_FILE_IN}
+flexsource.variable_out = SOURCES
+flexsource.name = Flex Sources ${QMAKE_FILE_IN}
+
+QMAKE_EXTRA_COMPILERS += flexsource
+
+flexheader.input = FLEXSOURCES
+flexheader.output = ${QMAKE_FILE_BASE}.h
+flexheader.commands = @true
+flexheader.variable_out = HEADERS
+flexheader.name = Flex Headers ${QMAKE_FILE_IN}
+flexheader.CONFIG = no_link
+
+QMAKE_EXTRA_COMPILERS += flexheader

--- a/src/libraries/libKitsunemimiHanamiSegmentParser/src/parser.pro
+++ b/src/libraries/libKitsunemimiHanamiSegmentParser/src/parser.pro
@@ -1,0 +1,38 @@
+QT -= qt core gui
+TEMPLATE = aux
+CONFIG += c++17 staticlib
+
+LIBS += -L../../libKitsunemimiCommon/src -lKitsunemimiCommon
+LIBS += -L../../libKitsunemimiCommon/src/debug -lKitsunemimiCommon
+LIBS += -L../../libKitsunemimiCommon/src/release -lKitsunemimiCommon
+INCLUDEPATH += ../../libKitsunemimiCommon/include
+
+LIBS += -L../../libKitsunemimiHanamiCommon/src -lKitsunemimiHanamiCommon
+LIBS += -L../../libKitsunemimiHanamiCommon/src/debug -lKitsunemimiHanamiCommon
+LIBS += -L../../libKitsunemimiHanamiCommon/src/release -lKitsunemimiHanamiCommon
+INCLUDEPATH += ../../libKitsunemimiHanamiCommon/include
+
+INCLUDEPATH += $$PWD \
+               $$PWD/../include
+
+BISONSOURCES = grammar/segment_parser.y
+
+OTHER_FILES +=  \
+    $$BISONSOURCES
+
+bisonsource.input = BISONSOURCES
+bisonsource.output = ${QMAKE_FILE_BASE}.cpp
+bisonsource.commands = bison -d --defines=${QMAKE_FILE_BASE}.h -o ${QMAKE_FILE_BASE}.cpp ${QMAKE_FILE_IN}
+bisonsource.variable_out = SOURCES
+bisonsource.name = Bison Sources ${QMAKE_FILE_IN}
+
+QMAKE_EXTRA_COMPILERS += bisonsource
+
+bisonheader.input = BISONSOURCES
+bisonheader.output = ${QMAKE_FILE_BASE}.h
+bisonheader.commands = @true
+bisonheader.variable_out = HEADERS
+bisonheader.name = Bison Headers ${QMAKE_FILE_IN}
+bisonheader.CONFIG =  no_link
+
+QMAKE_EXTRA_COMPILERS += bisonheader

--- a/src/libraries/libKitsunemimiIni/libKitsunemimiIni.pro
+++ b/src/libraries/libKitsunemimiIni/libKitsunemimiIni.pro
@@ -1,7 +1,15 @@
 TEMPLATE = subdirs
 CONFIG += ordered
 
-SUBDIRS = src
+lexxer.file = src/lexxer.pro
+parser.file = src/parser.pro
+
+SUBDIRS = parser
+SUBDIRS += lexxer
+SUBDIRS += src
+
+lexxer.depends = parser
+src.depends = lexxer
 
 run_tests {
     SUBDIRS += tests

--- a/src/libraries/libKitsunemimiIni/src/lexxer.pro
+++ b/src/libraries/libKitsunemimiIni/src/lexxer.pro
@@ -1,0 +1,36 @@
+QT -= qt core gui
+TEMPLATE = aux
+CONFIG += c++17 staticlib
+
+LIBS += -L../../libKitsunemimiCommon/src -lKitsunemimiCommon
+LIBS += -L../../libKitsunemimiCommon/src/debug -lKitsunemimiCommon
+LIBS += -L../../libKitsunemimiCommon/src/release -lKitsunemimiCommon
+INCLUDEPATH += ../../libKitsunemimiCommon/include
+
+INCLUDEPATH += $$PWD \
+               $$PWD/../include
+
+FLEXSOURCES = grammar/ini_lexer.l
+
+OTHER_FILES +=  \
+    $$FLEXSOURCES 
+
+# The following code calls the flex-lexer and bison-parser before compiling the
+# cpp-code for automatic generation of the parser-code in each build-step.
+# The resulting source-code-files are stored in the build-directory of the json-converter.
+flexsource.input = FLEXSOURCES
+flexsource.output = ${QMAKE_FILE_BASE}.cpp
+flexsource.commands = flex --header-file=${QMAKE_FILE_BASE}.h -o ${QMAKE_FILE_BASE}.cpp ${QMAKE_FILE_IN}
+flexsource.variable_out = SOURCES
+flexsource.name = Flex Sources ${QMAKE_FILE_IN}
+
+QMAKE_EXTRA_COMPILERS += flexsource
+
+flexheader.input = FLEXSOURCES
+flexheader.output = ${QMAKE_FILE_BASE}.h
+flexheader.commands = @true
+flexheader.variable_out = HEADERS
+flexheader.name = Flex Headers ${QMAKE_FILE_IN}
+flexheader.CONFIG = no_link
+
+QMAKE_EXTRA_COMPILERS += flexheader

--- a/src/libraries/libKitsunemimiIni/src/parser.pro
+++ b/src/libraries/libKitsunemimiIni/src/parser.pro
@@ -1,0 +1,33 @@
+QT -= qt core gui
+TEMPLATE = aux
+CONFIG += c++17 staticlib
+
+LIBS += -L../../libKitsunemimiCommon/src -lKitsunemimiCommon
+LIBS += -L../../libKitsunemimiCommon/src/debug -lKitsunemimiCommon
+LIBS += -L../../libKitsunemimiCommon/src/release -lKitsunemimiCommon
+INCLUDEPATH += ../../libKitsunemimiCommon/include
+
+INCLUDEPATH += $$PWD \
+               $$PWD/../include
+
+BISONSOURCES = grammar/ini_parser.y
+
+OTHER_FILES +=  \
+    $$BISONSOURCES
+
+bisonsource.input = BISONSOURCES
+bisonsource.output = ${QMAKE_FILE_BASE}.cpp
+bisonsource.commands = bison -d --defines=${QMAKE_FILE_BASE}.h -o ${QMAKE_FILE_BASE}.cpp ${QMAKE_FILE_IN}
+bisonsource.variable_out = SOURCES
+bisonsource.name = Bison Sources ${QMAKE_FILE_IN}
+
+QMAKE_EXTRA_COMPILERS += bisonsource
+
+bisonheader.input = BISONSOURCES
+bisonheader.output = ${QMAKE_FILE_BASE}.h
+bisonheader.commands = @true
+bisonheader.variable_out = HEADERS
+bisonheader.name = Bison Headers ${QMAKE_FILE_IN}
+bisonheader.CONFIG =  no_link
+
+QMAKE_EXTRA_COMPILERS += bisonheader

--- a/src/libraries/libKitsunemimiJson/libKitsunemimiJson.pro
+++ b/src/libraries/libKitsunemimiJson/libKitsunemimiJson.pro
@@ -3,7 +3,15 @@ CONFIG += ordered
 QT -= qt core gui
 CONFIG += c++14
 
-SUBDIRS = src
+lexxer.file = src/lexxer.pro
+parser.file = src/parser.pro
+
+SUBDIRS = parser
+SUBDIRS += lexxer
+SUBDIRS += src
+
+lexxer.depends = parser
+src.depends = lexxer
 
 run_tests {
     SUBDIRS += tests

--- a/src/libraries/libKitsunemimiJson/src/lexxer.pro
+++ b/src/libraries/libKitsunemimiJson/src/lexxer.pro
@@ -1,0 +1,36 @@
+QT -= qt core gui
+TEMPLATE = aux
+CONFIG += c++17 staticlib
+
+LIBS += -L../../libKitsunemimiCommon/src -lKitsunemimiCommon
+LIBS += -L../../libKitsunemimiCommon/src/debug -lKitsunemimiCommon
+LIBS += -L../../libKitsunemimiCommon/src/release -lKitsunemimiCommon
+INCLUDEPATH += ../../libKitsunemimiCommon/include
+
+INCLUDEPATH += $$PWD \
+               $$PWD/../include
+
+FLEXSOURCES = grammar/json_lexer.l
+
+OTHER_FILES +=  \
+    $$FLEXSOURCES 
+
+# The following code calls the flex-lexer and bison-parser before compiling the
+# cpp-code for automatic generation of the parser-code in each build-step.
+# The resulting source-code-files are stored in the build-directory of the json-converter.
+flexsource.input = FLEXSOURCES
+flexsource.output = ${QMAKE_FILE_BASE}.cpp
+flexsource.commands = flex --header-file=${QMAKE_FILE_BASE}.h -o ${QMAKE_FILE_BASE}.cpp ${QMAKE_FILE_IN}
+flexsource.variable_out = SOURCES
+flexsource.name = Flex Sources ${QMAKE_FILE_IN}
+
+QMAKE_EXTRA_COMPILERS += flexsource
+
+flexheader.input = FLEXSOURCES
+flexheader.output = ${QMAKE_FILE_BASE}.h
+flexheader.commands = @true
+flexheader.variable_out = HEADERS
+flexheader.name = Flex Headers ${QMAKE_FILE_IN}
+flexheader.CONFIG = no_link
+
+QMAKE_EXTRA_COMPILERS += flexheader

--- a/src/libraries/libKitsunemimiJson/src/parser.pro
+++ b/src/libraries/libKitsunemimiJson/src/parser.pro
@@ -1,0 +1,33 @@
+QT -= qt core gui
+TEMPLATE = aux
+CONFIG += c++17 staticlib
+
+LIBS += -L../../libKitsunemimiCommon/src -lKitsunemimiCommon
+LIBS += -L../../libKitsunemimiCommon/src/debug -lKitsunemimiCommon
+LIBS += -L../../libKitsunemimiCommon/src/release -lKitsunemimiCommon
+INCLUDEPATH += ../../libKitsunemimiCommon/include
+
+INCLUDEPATH += $$PWD \
+               $$PWD/../include
+
+BISONSOURCES = grammar/json_parser.y
+
+OTHER_FILES +=  \
+    $$BISONSOURCES
+
+bisonsource.input = BISONSOURCES
+bisonsource.output = ${QMAKE_FILE_BASE}.cpp
+bisonsource.commands = bison -d --defines=${QMAKE_FILE_BASE}.h -o ${QMAKE_FILE_BASE}.cpp ${QMAKE_FILE_IN}
+bisonsource.variable_out = SOURCES
+bisonsource.name = Bison Sources ${QMAKE_FILE_IN}
+
+QMAKE_EXTRA_COMPILERS += bisonsource
+
+bisonheader.input = BISONSOURCES
+bisonheader.output = ${QMAKE_FILE_BASE}.h
+bisonheader.commands = @true
+bisonheader.variable_out = HEADERS
+bisonheader.name = Bison Headers ${QMAKE_FILE_IN}
+bisonheader.CONFIG =  no_link
+
+QMAKE_EXTRA_COMPILERS += bisonheader


### PR DESCRIPTION
## Description

When using multiple threads while compiling, for example "make -j8" it resulted in a race-condition. The parser-code was generated at the same time when result was required by the code. Workaround until now was to build with only one threads, which is very slow.
Now an additional prestep in the affected libraries was added to run bison and flex in the correct order before the normal source-code.

## Related Issues

- #30 

## How it was tested?

- ci-pipeline
