### PR TITLE
Change (#9): Make name-field in database mandatory

### DIFF
--- a/src/components/KyoukoMind/src/database/cluster_table.cpp
+++ b/src/components/KyoukoMind/src/database/cluster_table.cpp
@@ -35,11 +35,6 @@ ClusterTable::ClusterTable(Kitsunemimi::Sakura::SqlDatabase* db)
     : HanamiSqlTable(db)
 {
     m_tableName = "clusters";
-
-    DbHeaderEntry clusterName;
-    clusterName.name = "name";
-    clusterName.maxLength = 256;
-    m_tableHeader.push_back(clusterName);
 }
 
 /**

--- a/src/components/KyoukoMind/src/database/template_table.cpp
+++ b/src/components/KyoukoMind/src/database/template_table.cpp
@@ -36,11 +36,6 @@ TemplateTable::TemplateTable(Kitsunemimi::Sakura::SqlDatabase* db)
 {
     m_tableName = "templates";
 
-    DbHeaderEntry templateName;
-    templateName.name = "name";
-    templateName.maxLength = 256;
-    m_tableHeader.push_back(templateName);
-
     DbHeaderEntry templateString;
     templateString.name = "data";
     templateString.hide = true;

--- a/src/components/ShioriArchive/src/database/cluster_snapshot_table.cpp
+++ b/src/components/ShioriArchive/src/database/cluster_snapshot_table.cpp
@@ -38,11 +38,6 @@ ClusterSnapshotTable::ClusterSnapshotTable(Kitsunemimi::Sakura::SqlDatabase* db)
 {
     m_tableName = "cluster_snapshot";
 
-    DbHeaderEntry name;
-    name.name = "name";
-    name.maxLength = 256;
-    m_tableHeader.push_back(name);
-
     DbHeaderEntry header;
     header.name = "header";
     header.hide = true;

--- a/src/components/ShioriArchive/src/database/data_set_table.cpp
+++ b/src/components/ShioriArchive/src/database/data_set_table.cpp
@@ -38,11 +38,6 @@ DataSetTable::DataSetTable(Kitsunemimi::Sakura::SqlDatabase* db)
 {
     m_tableName = "data_set";
 
-    DbHeaderEntry name;
-    name.name = "name";
-    name.maxLength = 256;
-    m_tableHeader.push_back(name);
-
     DbHeaderEntry type;
     type.name = "type";
     type.maxLength = 64;

--- a/src/components/ShioriArchive/src/database/request_result_table.cpp
+++ b/src/components/ShioriArchive/src/database/request_result_table.cpp
@@ -38,11 +38,6 @@ RequestResultTable::RequestResultTable(Kitsunemimi::Sakura::SqlDatabase* db)
 {
     m_tableName = "request_result";
 
-    DbHeaderEntry name;
-    name.name = "name";
-    name.maxLength = 256;
-    m_tableHeader.push_back(name);
-
     DbHeaderEntry data;
     data.name = "data";
     data.hide = true;

--- a/src/libraries/libKitsunemimiHanamiDatabase/src/hanami_sql_table.cpp
+++ b/src/libraries/libKitsunemimiHanamiDatabase/src/hanami_sql_table.cpp
@@ -60,6 +60,11 @@ HanamiSqlTable::HanamiSqlTable(Kitsunemimi::Sakura::SqlDatabase* db)
     visibility.name = "visibility";
     visibility.maxLength = 10;
     m_tableHeader.push_back(visibility);
+
+    DbHeaderEntry name;
+    name.name = "name";
+    name.maxLength = 256;
+    m_tableHeader.push_back(name);
 }
 
 /**


### PR DESCRIPTION
## Description

Moved the name-filed to the general table-definition in libKitsunemimiHanamiDatabase in order to make the field mandatory for general database tables.

## Related Issues

- #9 

## How it was tested?

- Tsugumi
