### PR TITLE
Change (#51): make token-expire time configurable

### DIFF
--- a/deploy/k8s/hanami-ai/templates/misaki-config.yaml
+++ b/deploy/k8s/hanami-ai/templates/misaki-config.yaml
@@ -12,6 +12,7 @@ data:
     [misaki]
     token_key_path = "/etc/misaki/token_key"
     policies = "/etc/misaki/policies"
+    token_expire_time = 3600
 
     #[azuki]
     #address = "/tmp/azuki.uds"

--- a/src/components/MisakiGuard/src/api/v1/auth/create_token.cpp
+++ b/src/components/MisakiGuard/src/api/v1/auth/create_token.cpp
@@ -27,6 +27,7 @@
 #include <libKitsunemimiCrypto/hashes.h>
 #include <libKitsunemimiJwt/jwt.h>
 #include <libKitsunemimiJson/json_item.h>
+#include <libKitsunemimiConfig/config_handler.h>
 
 #include <libKitsunemimiHanamiCommon/enums.h>
 #include <libKitsunemimiHanamiCommon/defines.h>
@@ -151,9 +152,17 @@ CreateToken::runTask(BlossomIO &blossomIO,
         return false;
     }
 
+    // get expire-time from config
+    bool success = false;
+    const u_int32_t expireTime = GET_INT_CONFIG("misaki", "token_expire_time", success);
+    if(success == false)
+    {
+        error.addMeesage("Could not read 'token_expire_time' from config of misaki.");
+        status.statusCode = Kitsunemimi::Hanami::INTERNAL_SERVER_ERROR_RTYPE;
+    }
+
     // create token
-    // TODO: make validation-time configurable
-    if(MisakiRoot::jwt->create_HS256_Token(jwtToken, userData, 3600, error) == false)
+    if(MisakiRoot::jwt->create_HS256_Token(jwtToken, userData, expireTime, error) == false)
     {
         error.addMeesage("Failed to create JWT-Token");
         status.statusCode = Kitsunemimi::Hanami::INTERNAL_SERVER_ERROR_RTYPE;

--- a/src/components/MisakiGuard/src/config.h
+++ b/src/components/MisakiGuard/src/config.h
@@ -35,8 +35,9 @@ registerConfigs(Kitsunemimi::ErrorContainer &error)
 {
     Kitsunemimi::Hanami::registerBasicConfigs(error);
 
-    REGISTER_STRING_CONFIG("misaki", "token_key_path", error, "", true);
-    REGISTER_STRING_CONFIG("misaki", "policies", error, "", true);
+    REGISTER_STRING_CONFIG("misaki", "token_key_path",    error, "",   true);
+    REGISTER_INT_CONFIG(   "misaki", "token_expire_time", error, 3600, true);
+    REGISTER_STRING_CONFIG("misaki", "policies",          error, "",   true);
 
 }
 


### PR DESCRIPTION
## Description

The expire time for JWT-token can now be configured by a new config-variable in the config-file of misaki. Default: 3600 seconds

## Related Issues

- #51 

## How it was tested?

- Manually testing via Dashboard an a very short expired time.
