### PR TITLE
Change (#85): Make token-key configurable

### DIFF
--- a/deploy/k8s/hanami-ai/templates/hanami-deployment.yaml
+++ b/deploy/k8s/hanami-ai/templates/hanami-deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       initContainers:
       - name: dashboard-container
-        image: kitsudaiki/hanami_ai_dashboard:{{ .Values.docker_tag }}
+        image: kitsudaiki/hanami_ai_dashboard:{{ .Values.docker.tag }}
         imagePullPolicy: Always
         securityContext:
           runAsUser: 0
@@ -26,15 +26,15 @@ spec:
           mountPath: /etc/torii/Hanami-AI-Dashboard
       containers:
       - name: misaki
-        image: kitsudaiki/misaki_guard:{{ .Values.docker_tag }}
+        image: kitsudaiki/misaki_guard:{{ .Values.docker.tag }}
         imagePullPolicy: Always
         env:
         - name: HANAMI_ADMIN_USER_ID
-          value: {{ .Values.user_id }}
+          value: {{ .Values.user.id }}
         - name: HANAMI_ADMIN_USER_NAME
-          value: {{ .Values.user_name }}
+          value: {{ .Values.user.name }}
         - name: HANAMI_ADMIN_PASSWORD
-          value: {{ .Values.user_pw }}
+          value: {{ .Values.user.pw }}
         volumeMounts:
         - name: misaki-config
           mountPath: /etc/misaki/misaki.conf
@@ -48,7 +48,7 @@ spec:
         - name: hanami-sockets-volume
           mountPath: /tmp/hanami
       - name: shiori
-        image: kitsudaiki/shiori_archive:{{ .Values.docker_tag }}
+        image: kitsudaiki/shiori_archive:{{ .Values.docker.tag }}
         imagePullPolicy: Always
         volumeMounts:
         - name: shiori-config
@@ -59,7 +59,7 @@ spec:
         - name: hanami-sockets-volume
           mountPath: /tmp/hanami
       - name: kyouko
-        image: kitsudaiki/kyouko_mind:{{ .Values.docker_tag }}
+        image: kitsudaiki/kyouko_mind:{{ .Values.docker.tag }}
         imagePullPolicy: Always
         volumeMounts:
         - name: kyouko-config
@@ -68,7 +68,7 @@ spec:
         - name: hanami-sockets-volume
           mountPath: /tmp/hanami
       - name: azuki
-        image: kitsudaiki/azuki_heart:{{ .Values.docker_tag }}
+        image: kitsudaiki/azuki_heart:{{ .Values.docker.tag }}
         imagePullPolicy: Always
         securityContext:
           privileged: true
@@ -79,7 +79,7 @@ spec:
         - name: hanami-sockets-volume
           mountPath: /tmp/hanami
       - name: torii
-        image: kitsudaiki/torii_gateway:{{ .Values.docker_tag }}
+        image: kitsudaiki/torii_gateway:{{ .Values.docker.tag }}
         imagePullPolicy: Always
         volumeMounts:
         - name: torii-config

--- a/deploy/k8s/hanami-ai/templates/misaki-config.yaml
+++ b/deploy/k8s/hanami-ai/templates/misaki-config.yaml
@@ -12,7 +12,7 @@ data:
     [misaki]
     token_key_path = "/etc/misaki/token_key"
     policies = "/etc/misaki/policies"
-    token_expire_time = 3600
+    token_expire_time = {{ .Values.token.expire_time }}
 
     #[azuki]
     #address = "/tmp/azuki.uds"

--- a/deploy/k8s/hanami-ai/templates/token-key.yaml
+++ b/deploy/k8s/hanami-ai/templates/token-key.yaml
@@ -3,6 +3,6 @@ metadata:
   name: token-key
 data:
   token_key: |
-    asdf
+    {{ .Values.token.pw }}
 
 kind: ConfigMap

--- a/deploy/k8s/hanami-ai/values.yaml
+++ b/deploy/k8s/hanami-ai/values.yaml
@@ -4,11 +4,17 @@
 
 replicaCount: 1
 
-user_id: "test_user"
-user_name: "Test User"
-user_pw: "asdfasdf"
+user:
+  id: "test_user"
+  name: "Test User"
+  pw: "asdfasdf"
 
-docker_tag: "develop"
+token:
+  pw: "asdf"
+  expire_time: 3600
+
+docker:
+  tag: "develop"
 
 
 resources: {}

--- a/docs/How_To/1_installation.md
+++ b/docs/How_To/1_installation.md
@@ -48,9 +48,10 @@ git clone https://github.com/kitsudaiki/Hanami-AI.git
 cd Hanami-AI/deploy/k8s
 
 helm install ./hanami-ai/ --generate-name \
-    --set user_id=USER_ID  \
-    --set user_name=USER_NAME  \
-    --set user_pw=PASSWORD
+    --set user.id=USER_ID  \
+    --set user.name=USER_NAME  \
+    --set user.pw=PASSWORD  \
+    --set token.pw=TOKEN_KEY
 ```
 
 The `--set`-flag defining the login-information for the initial admin-user of the instance:
@@ -66,6 +67,10 @@ The `--set`-flag defining the login-information for the initial admin-user of th
 - `PASSWORD`
     - Password for the initial user
     - String, with between `8` and `4096` characters length
+
+- `TOKEN_KEY`
+    - Key for the JWT-Tokens provided by Misaki
+    - String
 
 After a successful installation the `USER_ID` and `PASSWORD` have to be used for login to the system.
 


### PR DESCRIPTION
## Description

The key for the jwt-token of Misaki is now configurable by the values of the helm-chart.
In context of this commit the values of the helm-chart were a bit restructured in general for a cleaner
structure.

## Related Issues

- #85 

## How it was tested?

- Deploy with helm-chart and check the key within the container of Misaki
