### PR TITLE
Change (#91): Remove old server from Torii

### DIFF
--- a/deploy/k8s/hanami-ai/templates/torii-config.yaml
+++ b/deploy/k8s/hanami-ai/templates/torii-config.yaml
@@ -8,13 +8,6 @@ data:
     log_path = "/var/log/torii"
     address = "/tmp/hanami/torii.uds"
 
-    [sakura]
-    enable = True
-    ip = "0.0.0.0"
-    certificate = "/etc/torii/cert.pem"
-    key = "/etc/torii/key.pem"
-    port = 1338
-
     [http]
     enable = True
     ip = "0.0.0.0"

--- a/src/components/ToriiGateway/src/config.h
+++ b/src/components/ToriiGateway/src/config.h
@@ -47,14 +47,6 @@ registerConfigs(Kitsunemimi::ErrorContainer &error)
     REGISTER_STRING_CONFIG( httpGroup, "ip",                error, "0.0.0.0", true);
     REGISTER_INT_CONFIG(    httpGroup, "port",              error, 12345,     true);
     REGISTER_INT_CONFIG(    httpGroup, "number_of_threads", error, 4);
-
-    // sakura-section
-    const std::string sakuraGroup = "sakura";
-    REGISTER_BOOL_CONFIG(   sakuraGroup, "enable",          error, false);
-    REGISTER_STRING_CONFIG( sakuraGroup, "certificate",     error, "",        true);
-    REGISTER_STRING_CONFIG( sakuraGroup, "key",             error, "",        true);
-    REGISTER_STRING_CONFIG( sakuraGroup, "ip",              error, "0.0.0.0", true);
-    REGISTER_INT_CONFIG(    sakuraGroup, "port",            error, 12345,     true);
 }
 
 bool

--- a/src/components/ToriiGateway/src/torii_root.cpp
+++ b/src/components/ToriiGateway/src/torii_root.cpp
@@ -60,13 +60,6 @@ ToriiGateway::init()
         return false;
     }
 
-    if(initSakuraServer() == false)
-    {
-        error.addMeesage("initializing sakura-server failed");
-        LOG_ERROR(error);
-        return false;
-    }
-
     return true;
 }
 
@@ -105,35 +98,6 @@ ToriiGateway::initHttpServer()
         httpWebsocketThread->startThread();
         m_threads.push_back(httpWebsocketThread);
     }
-
-    return true;
-}
-
-/**
- * @brief initialze sakura server
- *
- * @return true, if successful, else false
- */
-bool
-ToriiGateway::initSakuraServer()
-{
-    bool success = false;
-
-    // check if sakura-server is enabled
-    if(GET_BOOL_CONFIG("sakura", "enable", success) == false) {
-        return true;
-    }
-
-    // get stuff from config
-    const uint16_t port =    GET_INT_CONFIG(    "sakura", "port",        success);
-    const std::string ip =   GET_STRING_CONFIG( "sakura", "ip",          success);
-    const std::string cert = GET_STRING_CONFIG( "sakura", "certificate", success);
-    const std::string key =  GET_STRING_CONFIG( "sakura", "key",         success);
-
-    // create server
-    Kitsunemimi::ErrorContainer error;
-    HanamiMessaging* messaging = HanamiMessaging::getInstance();
-    messaging->addServer(ip, error, port, cert, key);
 
     return true;
 }


### PR DESCRIPTION
## Description

Removed the old unused sakura-server from Torii, because it was replaced by websockets, which are also using the HTTP-port.

## Related Issues

- #91 

## How it was tested?

- Tsugumi
