### PR TITLE
Fix (#113): fix json-parser for exponents in float-values

### DIFF
--- a/src/core/Hanami/src/api/endpoint_processing/http_websocket_thread.cpp
+++ b/src/core/Hanami/src/api/endpoint_processing/http_websocket_thread.cpp
@@ -460,10 +460,10 @@ HttpWebsocketThread::runWebsocket()
                 std::string response = "{\"success\":" + std::to_string(success);
                 if(success)
                 {
-                    response.append(",\"uuid\":");
+                    response.append(",\"uuid\":\"");
                     response.append(m_uuid);
                 }
-                response.append("}");
+                response.append("\"}");
 
                 m_webSocket->binary(true);
                 m_webSocket->write(net::buffer(response, response.size()));

--- a/src/libraries/libKitsunemimiJson/src/grammar/json_lexer.l
+++ b/src/libraries/libKitsunemimiJson/src/grammar/json_lexer.l
@@ -55,6 +55,7 @@ blank [ \t]
 "]"       return Kitsunemimi::JsonParser::make_BRACKCLOSE (jsonloc);
 ","       return Kitsunemimi::JsonParser::make_COMMA (jsonloc);
 ":"       return Kitsunemimi::JsonParser::make_ASSIGN (jsonloc);
+"e+"      return Kitsunemimi::JsonParser::make_EXPONENT (jsonloc);
 
 "true" return Kitsunemimi::JsonParser::make_BOOL_TRUE (jsonloc);
 "false" return Kitsunemimi::JsonParser::make_BOOL_FALSE (jsonloc);
@@ -80,10 +81,6 @@ blank [ \t]
 }
 
 {id}       return Kitsunemimi::JsonParser::make_IDENTIFIER(yytext, jsonloc);
-
-[a-zA-Z_0-9|\-|.]* {
-    return Kitsunemimi::JsonParser::make_STRING_PLN(yytext, jsonloc);
-}
 
 .          driver.error(jsonloc, "invalid character");
 <<EOF>>    return Kitsunemimi::JsonParser::make_END(jsonloc);

--- a/src/libraries/libKitsunemimiJson/src/grammar/json_parser.y
+++ b/src/libraries/libKitsunemimiJson/src/grammar/json_parser.y
@@ -23,6 +23,7 @@
 {
 #include <string>
 #include <iostream>
+#include <cmath>
 #include <libKitsunemimiCommon/items/data_items.h>
 
 using Kitsunemimi::DataItem;
@@ -63,6 +64,7 @@ YY_DECL;
     BRACKCLOSE  "]"
     COMMA  ","
     ASSIGN  ":"
+    EXPONENT "e+"
     BOOL_TRUE  "true"
     BOOL_FALSE "false"
     NULLVAL "null"
@@ -71,7 +73,6 @@ YY_DECL;
 
 %token <std::string> IDENTIFIER "identifier"
 %token <std::string> STRING "string"
-%token <std::string> STRING_PLN "string_pln"
 %token <long> NUMBER "number"
 %token <double> FLOAT "float"
 
@@ -156,24 +157,6 @@ json_object_content:
         }
     }
 |
-    json_object_content "," "string_pln" ":" json_abstract
-    {
-        if(driver.dryRun == false) {
-            $1->insert(driver.removeQuotes($3), $5);
-        }
-        $$ = $1;
-    }
-|
-    "string_pln" ":" json_abstract
-    {
-        if(driver.dryRun == false) {
-            $$ = new DataMap();
-            $$->insert(driver.removeQuotes($1), $3);
-        } else {
-            $$ = nullptr;
-        }
-    }
-|
     json_object_content "," "string" ":" json_abstract
     {
         if(driver.dryRun == false) {
@@ -227,13 +210,6 @@ json_array_content:
     }
 
 json_value:
-    "string_pln"
-    {
-        if(driver.dryRun == false) {
-            $$ = new DataValue($1);
-        }
-    }
-|
     "identifier"
     {
         if(driver.dryRun == false) {
@@ -248,6 +224,19 @@ json_value:
         if(driver.dryRun == false) {
             $$ = new DataValue($1);
         } else {
+            $$ = nullptr;
+        }
+    }
+|
+    "float" "e+" "number"
+    {
+        if(driver.dryRun == false)
+        {
+            float value = $1;
+            value *= std::pow(10, $3);
+            $$ = new DataValue(value);
+        }
+        else {
             $$ = nullptr;
         }
     }

--- a/src/libraries/libKitsunemimiJson/tests/unit_tests/libKitsunemimiJson/json_item_test.cpp
+++ b/src/libraries/libKitsunemimiJson/tests/unit_tests/libKitsunemimiJson/json_item_test.cpp
@@ -419,7 +419,7 @@ JsonItem_Test::getTestItem()
 {
     std::string input("{\n"
                       "    item: {\n"
-                      "        sub_item: \"test_value\"\n"
+                      "        \"sub_item\": \"test_value\"\n"
                       "    },\n"
                       "    item2: {\n"
                       "        sub_item2: \"something\"\n"
@@ -433,7 +433,7 @@ JsonItem_Test::getTestItem()
                       "        },\n"
                       "        1234,\n"
                       "        {\n"
-                      "            x: -42.000000\n"
+                      "            x: -42.000000e+02\n"
                       "        }\n"
                       "    ]\n"
                       "}");
@@ -441,7 +441,7 @@ JsonItem_Test::getTestItem()
     JsonItem output;
     ErrorContainer error;
     output.parse(input, error);
-
+    //std::cout<<error.toString()<<std::endl;
     assert(output.isValid());
 
     return output;


### PR DESCRIPTION
## Description

Fix json-parser to be able to parse values like "42.000000e+02"

## Related Issues

- #113 

## How it was tested?

- SDK-API-Tester