### PR TITLE
Change (#121): reduce list of possible target-bricks

### DIFF
--- a/src/core/Hanami/src/core/segments/brick.h
+++ b/src/core/Hanami/src/core/segments/brick.h
@@ -33,7 +33,8 @@ struct Brick
     uint32_t brickId = UNINIT_STATE_32;
     bool isOutputBrick = false;
     bool isInputBrick = false;
-    uint8_t padding1[14];
+    uint8_t padding1[10];
+    uint32_t numberOfPossibleBricks = 0;
     uint32_t neuronSectionPos = UNINIT_STATE_32;
 
     uint32_t numberOfNeurons = 0;
@@ -41,7 +42,38 @@ struct Brick
 
     Kitsunemimi::Position brickPos;
     uint32_t neighbors[12];
-    uint32_t possibleTargetNeuronBrickIds[1000];
+    uint32_t possibleTargetBrickIds[1000];
+
+    Brick()
+    {
+        for(uint32_t i = 0; i < 1000; i++) {
+            possibleTargetBrickIds[i] = UNINIT_STATE_32;
+        }
+    }
+
+    void addPossibleBrick(const uint32_t possibleBrickId)
+    {
+        for(uint32_t i = 0; i < 1000-1; i++)
+        {
+            if(possibleTargetBrickIds[i] == possibleBrickId) {
+                return;
+            }
+            if(possibleTargetBrickIds[i] == UNINIT_STATE_32)
+            {
+                possibleTargetBrickIds[i] = possibleBrickId;
+                numberOfPossibleBricks++;
+            }
+        }
+    }
+
+    uint32_t getPossibleBrick()
+    {
+        const uint32_t result = possibleTargetBrickIds[0];
+        for(uint32_t i = 0; i < numberOfPossibleBricks; i++) {
+            possibleTargetBrickIds[i] = possibleTargetBrickIds[i+1];
+        }
+        return result;
+    }
 
     // total size: 4096 Bytes
 };

--- a/src/core/Hanami/src/core/segments/core_segment/core_segment.cpp
+++ b/src/core/Hanami/src/core/segments/core_segment/core_segment.cpp
@@ -793,7 +793,7 @@ CoreSegment::initTargetBrickList()
                 LOG_WARNING("brick has no next brick and is a dead-end. Brick-ID: "
                             + std::to_string(brickId));
             }
-            baseBrick->possibleTargetNeuronBrickIds[counter] = brickId;
+            baseBrick->addPossibleBrick(brickId);
         }
     }
 

--- a/src/core/Hanami/src/core/segments/core_segment/section_update.h
+++ b/src/core/Hanami/src/core/segments/core_segment/section_update.h
@@ -53,14 +53,11 @@ getForwardLast(const uint32_t sourceId,
 inline void
 createNewSection(SynapseSection &result,
                  CoreSegment &segment,
-                 const Brick &currentBrick,
+                 const uint32_t brickId,
                  const float offset)
 {
     result.connection.active = Kitsunemimi::ItemBuffer::ACTIVE_SECTION;
     result.connection.randomPos = rand() % NUMBER_OF_RAND_VALUES;
-    result.connection.randomPos = (result.connection.randomPos + 1) % NUMBER_OF_RAND_VALUES;
-    const uint32_t randVal = HanamiRoot::m_randomValues[result.connection.randomPos] % 1000;
-    const uint32_t brickId = currentBrick.possibleTargetNeuronBrickIds[randVal];
     result.connection.randomPos = (result.connection.randomPos + 1) % NUMBER_OF_RAND_VALUES;
     result.connection.offset = offset;
     result.connection.targetNeuronSectionId = segment.bricks[brickId].neuronSectionPos;
@@ -80,12 +77,16 @@ processUpdatePositon_CPU(CoreSegment &segment,
     NeuronSection* sourceNeuronSection = &segment.neuronSections[sourceNeuronSectionId];
     Neuron* sourceNeuron = &sourceNeuronSection->neurons[sourceNeuronId];
     Brick* currentBrick = &segment.bricks[sourceNeuronSection->brickId];
+    const uint32_t brickId = currentBrick->getPossibleBrick();
+    if(brickId == UNINIT_STATE_32) {
+        return;
+    }
 
     // create new section and connect it to buffer
     SynapseSection newSection;
     newSection.connection.sourceNeuronId = sourceNeuronId;
     newSection.connection.sourceNeuronSectionId = sourceNeuronSectionId;
-    createNewSection(newSection, segment, *currentBrick, offset);
+    createNewSection(newSection, segment, brickId, offset);
 
     const uint64_t newId = segment.segmentData.addNewItem(newSection);
     if(newId == ITEM_BUFFER_UNDEFINE_POS) {
@@ -116,12 +117,16 @@ processUpdatePositon_GPU(CoreSegment &segment,
     NeuronSection* sourceNeuronSection = &segment.neuronSections[sourceNeuronSectionId];
     Neuron* sourceNeuron = &sourceNeuronSection->neurons[sourceNeuronId];
     Brick* currentBrick = &segment.bricks[sourceNeuronSection->brickId];
+    const uint32_t brickId = currentBrick->getPossibleBrick();
+    if(brickId == UNINIT_STATE_32) {
+        return;
+    }
 
     // create new section and connect it to buffer
     SynapseSection newSection;
     newSection.connection.sourceNeuronId = sourceNeuronId;
     newSection.connection.sourceNeuronSectionId = sourceNeuronSectionId;
-    createNewSection(newSection, segment, *currentBrick, offset);
+    createNewSection(newSection, segment, brickId, offset);
     NeuronConnection* targetCon = &segment.neuronConnections[newSection.connection.targetNeuronSectionId];
     if(targetCon->backwardIds[NEURON_CONNECTIONS-1] != UNINIT_STATE_32) {
         return;


### PR DESCRIPTION
## Description

The list of possible brick-targets now contains only a limited list of unique ids, which can only be used one time per brick.

## Related Issues

- #121 

## How it was tested?

- SDK-API-Tester
