### PR TITLE
Fix (#130): remove cluster at start

### DIFF
--- a/src/Hanami/src/database/cluster_table.cpp
+++ b/src/Hanami/src/database/cluster_table.cpp
@@ -182,3 +182,17 @@ ClusterTable::deleteCluster(const std::string &clusterUuid,
 
     return true;
 }
+
+/**
+ * @brief delete all cluster from database. This currently used to avoid
+ *        broken empty clusters after a restart of the backend
+ *
+ * @param error reference for error-output
+ *
+ * @return true, if successful, else false
+ */
+bool
+ClusterTable::deleteAllCluster(Kitsunemimi::ErrorContainer &error)
+{
+    return deleteAllFromDb(error);
+}

--- a/src/Hanami/src/database/cluster_table.h
+++ b/src/Hanami/src/database/cluster_table.h
@@ -62,7 +62,7 @@ public:
     bool deleteCluster(const std::string &clusterUuid,
                        const UserContext &userContext,
                        Kitsunemimi::ErrorContainer &error);
-
+    bool deleteAllCluster(Kitsunemimi::ErrorContainer &error);
 private:
     ClusterTable();
     static ClusterTable* instance;

--- a/src/Hanami/src/hanami_root.cpp
+++ b/src/Hanami/src/hanami_root.cpp
@@ -99,12 +99,13 @@ HanamiRoot::init(Kitsunemimi::ErrorContainer &error)
         m_randomValues[i] = static_cast<uint32_t>(rand());
     }
 
-    // init db
     if(initDatabase(error) == false)
     {
         error.addMeesage("Failed to initialize database");
         return false;
     }
+
+    clearCluster(error);
 
     if(initJwt(error) == false)
     {
@@ -389,6 +390,17 @@ HanamiRoot::initJwt(Kitsunemimi::ErrorContainer &error)
 }
 
 /**
+ * @brief delete all clusters, because after a restart these are broken
+ */
+void
+HanamiRoot::clearCluster(Kitsunemimi::ErrorContainer &error)
+{
+    ClusterTable::getInstance()->deleteAllCluster(error);
+    // TODO: if a checkpoint exist for a broken cluster, then the cluster should be
+    //       restored with the last available checkpoint
+}
+
+/**
  * @brief check if a specific blossom was registered
  *
  * @param groupName group-identifier of the blossom
@@ -614,7 +626,7 @@ HanamiRoot::addEndpoint(const std::string &id,
 
     // search for id
     auto id_it = endpointRules.find(id);
-    if(endpointRules.find(id) != endpointRules.end())
+    if(id_it != endpointRules.end())
     {
         // search for http-type
         if(id_it->second.find(httpType) != id_it->second.end()) {

--- a/src/Hanami/src/hanami_root.h
+++ b/src/Hanami/src/hanami_root.h
@@ -111,6 +111,8 @@ private:
     bool initDatabase(Kitsunemimi::ErrorContainer &error);
     bool initPolicies(Kitsunemimi::ErrorContainer &error);
     bool initJwt(Kitsunemimi::ErrorContainer &error);
+
+    void clearCluster(Kitsunemimi::ErrorContainer &error);
 };
 
 #endif //HANAMI_HANAMI_ROOT_H


### PR DESCRIPTION
## Description

Cluster are in-memory, so they don't survive a restart of the backend. It left behind a empty broken cluster- corpse in the database behind without the cluster itself. This was more or less solved for now by removing all cluster from database while starting.
In the future the last available checkpoint should be loaded.

## Related Issues

- #130 

## How it was tested?

- manually created a cluster via dashboard and restarted the backend
