### PR TITLE
Add (#183): use node-labels in kubernetes

### DIFF
--- a/deploy/k8s/hanami/templates/hanami-deployment.yaml
+++ b/deploy/k8s/hanami/templates/hanami-deployment.yaml
@@ -14,6 +14,24 @@ spec:
       labels:
         app: hanami
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: hanami-node
+                operator: In
+                values:
+                - "true"
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: app
+                operator: In
+                values:
+                - hanami
+            topologyKey: kubernetes.io/hostname
       containers:
       - name: hanami
         image: {{ .Values.docker.registry }}/hanami:{{ .Values.docker.tag }}

--- a/docs/how_to/installation.md
+++ b/docs/how_to/installation.md
@@ -39,6 +39,18 @@ For the installation on a kubernetes `helm` is used.
     helm install cert-manager jetstack/cert-manager --namespace cert-manager --set installCRDs=true
     ```
 
+4. **Node label**
+
+    To all avaialbe nodes, where it is allowed to be deployed, the label `hanami-node` must be assigned
+
+    ```
+    kubectl label nodes NODE_NAME hanami-node=true
+    ```
+
+    !!! info
+
+        At the moment Hanami is only a single-node application. This will change in the near future, but at the moment it doesn't make sense to label more than one node.
+
 <!-- 3. If measuring of the cpu power consumption should be available, then the following requirements must be fulfilled on the hosts of the kubernetes-deployment:
 
     - Required specific CPU-architecture:


### PR DESCRIPTION
## Description

Deploy hanami in kubernetes setup only on
nodes with the label hanami-node and only
allow one pod per physical node of this type.

## Related Issues

- #183 

## How it was tested?

- different tests with local kubernetes-setup with and without label and with too many pods per node
