### PR TITLE
Change (#195): use clang++ instead of g++

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -44,7 +44,7 @@ jobs:
     needs: [ cpp-check, clang-format-check ]
     runs-on: ubuntu-latest
     container:
-      image: kitsudaiki/hanami_builder:0.4.0
+      image: kitsudaiki/hanami_builder:0.6.0
     name: "build repository"
     steps:
       - name: "Checkout repository"

--- a/Hanami.pro
+++ b/Hanami.pro
@@ -3,6 +3,9 @@ CONFIG += ordered
 QT -= qt core gui
 CONFIG += c++17
 
+QMAKE_CXX = clang++-15
+QMAKE_LINK = clang++-15
+
 SUBDIRS =  src/libraries
 SUBDIRS += src/sdk/cpp/hanami_sdk
 SUBDIRS += src/Hanami

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ If you need help to setup things, have a question or something like this, feel f
 - Ubuntu 22.04:
 
 ```
-sudo apt-get install -y git ssh gcc g++ gcc-12 g++-12 clang-format-15 make qt5-qmake bison flex libssl-dev libcrypto++-dev libboost1.74-dev uuid-dev  libsqlite3-dev protobuf-compiler 
+sudo apt-get install -y git ssh gcc g++ clang-format-15 make qt5-qmake bison flex libssl-dev libcrypto++-dev libboost1.74-dev uuid-dev  libsqlite3-dev protobuf-compiler 
 ```
 
 CUDA 12 is necessary, which is not in the standard apt-repositories below ubuntu 23.04. So in case it should be installed on 22.04, CUDA has to be installed manually with the manual: https://docs.nvidia.com/cuda/cuda-installation-guide-linux/index.html
@@ -96,7 +96,7 @@ CUDA 12 is necessary, which is not in the standard apt-repositories below ubuntu
 - Ubuntu 23.04
 
 ```
-sudo apt-get install -y git ssh gcc g++ gcc-12 g++-12 clang-format-15 make qt5-qmake bison flex libssl-dev libcrypto++-dev libboost1.74-dev uuid-dev  libsqlite3-dev protobuf-compiler nvidia-cuda-toolkit
+sudo apt-get install -y git ssh clang++-15 clang-format-15 make qt5-qmake bison flex libssl-dev libcrypto++-dev libboost1.74-dev uuid-dev  libsqlite3-dev protobuf-compiler nvidia-cuda-toolkit
 ```
 
 **Clone repo with:**

--- a/build.sh
+++ b/build.sh
@@ -5,9 +5,9 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 PARENT_DIR="$(dirname "$DIR")"
 
 if [ $1 = "test" ]; then
-    /usr/lib/x86_64-linux-gnu/qt5/bin/qmake "$PARENT_DIR/Hanami/Hanami.pro" -spec linux-g++ "CONFIG += optimize_full staticlib run_tests"
+    QMAKE_CXX=clang++  /usr/lib/x86_64-linux-gnu/qt5/bin/qmake "$PARENT_DIR/Hanami/Hanami.pro" -r -spec linux-clang "CONFIG += optimize_full staticlib run_tests"
 else
-    /usr/lib/x86_64-linux-gnu/qt5/bin/qmake "$PARENT_DIR/Hanami/Hanami.pro" -spec linux-g++ "CONFIG += optimize_full staticlib"
+    QMAKE_CXX=clang++  /usr/lib/x86_64-linux-gnu/qt5/bin/qmake "$PARENT_DIR/Hanami/Hanami.pro" -r -spec linux-clang "CONFIG += optimize_full staticlib"
 fi
 
 /usr/bin/make -j8

--- a/build/docker/Dockerfile
+++ b/build/docker/Dockerfile
@@ -1,10 +1,9 @@
-FROM ubuntu:22.04
+FROM ubuntu:23.04
 
 RUN apt-get update && \
-    apt-get install -y gcc \
+    apt-get install -y clang-15 \
+                       gcc \
                        g++ \
-                       gcc-12 \
-                       g++-12 \
                        make \
                        qt5-qmake \
                        bison \
@@ -17,21 +16,21 @@ RUN apt-get update && \
                        uuid-dev  \
                        libsqlite3-dev \
                        protobuf-compiler \
-                       nano 
-                       
-RUN export DEBIAN_FRONTEND=noninteractive && \
+                       nvidia-cuda-toolkit \
+                       nano \
+    && \
+    export DEBIAN_FRONTEND=noninteractive && \
     apt-get install -y apt-transport-https ca-certificates curl software-properties-common && \ 
     curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg && \
     echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null && \
     apt-get update  && \
-    apt-get install -y docker-ce
+    apt-get install -y docker-ce \
+    && \
+    apt-get clean autoclean &&\
+    apt-get autoremove --yes
 
-RUN export DEBIAN_FRONTEND=noninteractive && \
-    wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/cuda-keyring_1.1-1_all.deb && \
-    dpkg -i cuda-keyring_1.1-1_all.deb  && \
-    apt-get update && \
-    apt-get install -y cuda
-
+RUN ln -s /usr/bin/clang++-15 /usr/bin/clang++ && \
+    ln -s /usr/bin/clang-15 /usr/bin/clang
 RUN mkdir /dockerbuilder
 COPY files/build_hanami.sh /dockerbuilder 
 COPY files/Dockerfile_hanami /dockerbuilder

--- a/deploy/ansible/hanami/templates/hanami.service.j2
+++ b/deploy/ansible/hanami/templates/hanami.service.j2
@@ -1,0 +1,13 @@
+[Unit]
+Description="Start Hanami"
+After=network.target
+
+[Service]
+# Environment=NODE_PORT=30000
+Type=simple
+User={{ user }}
+ExecStart=/usr/bin/node {{ foundry_dir }}/resources/app/main.js --dataPath={{ foundrydata_dir }}
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target

--- a/docs/other/dependencies.md
+++ b/docs/other/dependencies.md
@@ -8,8 +8,7 @@ Installed packages under the actual used Ubuntu 23.04
 
 | apt-package | Purpose |
 | --- | --- |
-| gcc | C-compiler |
-| g++  | C++-compiler |
+| clang-15 | C++-compiler |
 | clang-format-15  | Helper for styling the source-code |
 | make  | Build-Tool |
 | qt5-qmake  | Qt-specific build-tool, because pro-files are used |
@@ -21,6 +20,8 @@ Installed packages under the actual used Ubuntu 23.04
 | uuid-dev  | Generate UUID's within the code |
 | libsqlite3-dev | Library to interact with the SQLite3 databases |
 | protobuf-compiler | Convert protobuf-files into source-code |
+| gcc | C-compiler |
+| g++  | C++-compiler |
 | nvidia-cuda-toolkit | Libraries and compiler for the CUDA-Kernel |
 
 !!! info

--- a/src/Hanami/Hanami.pro
+++ b/src/Hanami/Hanami.pro
@@ -4,6 +4,9 @@ TARGET = Hanami
 CONFIG += console
 CONFIG += c++17
 
+QMAKE_CXX = clang++-15
+QMAKE_LINK = clang++-15
+
 INCLUDEPATH += ../libraries/hanami_messages/protobuffers
 
 LIBS += -L../libraries/hanami_hardware/src -lhanami_hardware

--- a/src/libraries/hanami_args/hanami_args.pro
+++ b/src/libraries/hanami_args/hanami_args.pro
@@ -1,6 +1,9 @@
 TEMPLATE = subdirs
 CONFIG += ordered
 
+QMAKE_CXX = clang++-15
+QMAKE_LINK = clang++-15
+
 SUBDIRS = src
 
 run_tests {

--- a/src/libraries/hanami_args/src/src.pro
+++ b/src/libraries/hanami_args/src/src.pro
@@ -5,6 +5,9 @@ TEMPLATE = lib
 CONFIG += c++17
 VERSION = 0.4.0
 
+QMAKE_CXX = clang++-15
+QMAKE_LINK = clang++-15
+
 LIBS += -L../../hanami_common/src -lhanami_common
 LIBS += -L../../hanami_common/src/debug -lhanami_common
 LIBS += -L../../hanami_common/src/release -lhanami_common

--- a/src/libraries/hanami_args/tests/cli_tests/cli_tests.pro
+++ b/src/libraries/hanami_args/tests/cli_tests/cli_tests.pro
@@ -3,7 +3,10 @@ include(../../defaults.pri)
 QT -= qt core gui
 
 CONFIG   -= app_bundle
-CONFIG += c++14 console
+CONFIG += c++17 console
+
+QMAKE_CXX = clang++-15
+QMAKE_LINK = clang++-15
 
 LIBS += -L../../src -lhanami_args
 INCLUDEPATH += $$PWD

--- a/src/libraries/hanami_args/tests/tests.pro
+++ b/src/libraries/hanami_args/tests/tests.pro
@@ -3,6 +3,9 @@ CONFIG += ordered
 QT -= qt core gui
 CONFIG += c++17
 
+QMAKE_CXX = clang++-15
+QMAKE_LINK = clang++-15
+
 SUBDIRS = \
     unit_tests \
     cli_tests

--- a/src/libraries/hanami_args/tests/unit_tests/unit_tests.pro
+++ b/src/libraries/hanami_args/tests/unit_tests/unit_tests.pro
@@ -3,7 +3,10 @@ include(../../defaults.pri)
 QT -= qt core gui
 
 CONFIG   -= app_bundle
-CONFIG += c++14 console
+CONFIG += c++17 console
+
+QMAKE_CXX = clang++-15
+QMAKE_LINK = clang++-15
 
 LIBS += -L../../src -lhanami_args
 INCLUDEPATH += $$PWD

--- a/src/libraries/hanami_cluster_parser/hanami_cluster_parser.pro
+++ b/src/libraries/hanami_cluster_parser/hanami_cluster_parser.pro
@@ -1,7 +1,10 @@
 TEMPLATE = subdirs
 CONFIG += ordered
 QT -= qt core gui
-CONFIG += c++14
+CONFIG += c++17
+
+QMAKE_CXX = clang++-15
+QMAKE_LINK = clang++-15
 
 lexxer.file = src/lexxer.pro
 parser.file = src/parser.pro

--- a/src/libraries/hanami_cluster_parser/src/lexxer.pro
+++ b/src/libraries/hanami_cluster_parser/src/lexxer.pro
@@ -2,6 +2,9 @@ QT -= qt core gui
 TEMPLATE = aux
 CONFIG += c++17 staticlib
 
+QMAKE_CXX = clang++-15
+QMAKE_LINK = clang++-15
+
 LIBS += -L../../hanami_common/src -lhanami_common
 LIBS += -L../../hanami_common/src/debug -lhanami_common
 LIBS += -L../../hanami_common/src/release -lhanami_common

--- a/src/libraries/hanami_cluster_parser/src/parser.pro
+++ b/src/libraries/hanami_cluster_parser/src/parser.pro
@@ -2,6 +2,9 @@ QT -= qt core gui
 TEMPLATE = aux
 CONFIG += c++17 staticlib
 
+QMAKE_CXX = clang++-15
+QMAKE_LINK = clang++-15
+
 LIBS += -L../../hanami_common/src -lhanami_common
 LIBS += -L../../hanami_common/src/debug -lhanami_common
 LIBS += -L../../hanami_common/src/release -lhanami_common

--- a/src/libraries/hanami_cluster_parser/src/src.pro
+++ b/src/libraries/hanami_cluster_parser/src/src.pro
@@ -5,6 +5,9 @@ TEMPLATE = lib
 CONFIG += c++17
 VERSION = 0.1.0
 
+QMAKE_CXX = clang++-15
+QMAKE_LINK = clang++-15
+
 LIBS += -L../../hanami_common/src -lhanami_common
 LIBS += -L../../hanami_common/src/debug -lhanami_common
 LIBS += -L../../hanami_common/src/release -lhanami_common

--- a/src/libraries/hanami_cluster_parser/tests/memory_leak_tests/memory_leak_tests.pro
+++ b/src/libraries/hanami_cluster_parser/tests/memory_leak_tests/memory_leak_tests.pro
@@ -5,6 +5,9 @@ QT -= qt core gui
 CONFIG -= app_bundle
 CONFIG += c++17 console
 
+QMAKE_CXX = clang++-15
+QMAKE_LINK = clang++-15
+
 LIBS += -L../../src -lhanami_cluster_parser
 INCLUDEPATH += $$PWD
 

--- a/src/libraries/hanami_cluster_parser/tests/tests.pro
+++ b/src/libraries/hanami_cluster_parser/tests/tests.pro
@@ -3,6 +3,9 @@ CONFIG += ordered
 QT -= qt core gui
 CONFIG += c++17
 
+QMAKE_CXX = clang++-15
+QMAKE_LINK = clang++-15
+
 SUBDIRS = \
     unit_tests \
     memory_leak_tests

--- a/src/libraries/hanami_cluster_parser/tests/unit_tests/unit_tests.pro
+++ b/src/libraries/hanami_cluster_parser/tests/unit_tests/unit_tests.pro
@@ -5,6 +5,9 @@ QT -= qt core gui
 CONFIG -= app_bundle
 CONFIG += c++17 console
 
+QMAKE_CXX = clang++-15
+QMAKE_LINK = clang++-15
+
 LIBS += -L../../src -lhanami_cluster_parser
 INCLUDEPATH += $$PWD
 

--- a/src/libraries/hanami_common/hanami_common.pro
+++ b/src/libraries/hanami_common/hanami_common.pro
@@ -1,6 +1,9 @@
 TEMPLATE = subdirs
 CONFIG += ordered
 
+QMAKE_CXX = clang++-15
+QMAKE_LINK = clang++-15
+
 SUBDIRS = src
 
 run_tests {

--- a/src/libraries/hanami_common/src/src.pro
+++ b/src/libraries/hanami_common/src/src.pro
@@ -5,6 +5,9 @@ TEMPLATE = lib
 CONFIG += c++17
 VERSION = 0.26.1
 
+QMAKE_CXX = clang++-15
+QMAKE_LINK = clang++-15
+
 INCLUDEPATH += ../../../third-party-libs/json/include
 
 INCLUDEPATH += $$PWD \

--- a/src/libraries/hanami_common/tests/memory_leak_tests/memory_leak_tests.pro
+++ b/src/libraries/hanami_common/tests/memory_leak_tests/memory_leak_tests.pro
@@ -5,6 +5,9 @@ QT -= qt core gui
 CONFIG   -= app_bundle
 CONFIG += c++17 console
 
+QMAKE_CXX = clang++-15
+QMAKE_LINK = clang++-15
+
 LIBS += -L../../src -lhanami_common
 INCLUDEPATH += $$PWD
 INCLUDEPATH += ../../../../third-party-libs/json/include

--- a/src/libraries/hanami_common/tests/tests.pro
+++ b/src/libraries/hanami_common/tests/tests.pro
@@ -3,6 +3,9 @@ CONFIG += ordered
 QT -= qt core gui
 CONFIG += c++17
 
+QMAKE_CXX = clang++-15
+QMAKE_LINK = clang++-15
+
 SUBDIRS = \
     unit_tests \
     memory_leak_tests

--- a/src/libraries/hanami_common/tests/unit_tests/unit_tests.pro
+++ b/src/libraries/hanami_common/tests/unit_tests/unit_tests.pro
@@ -5,6 +5,9 @@ QT -= qt core gui
 CONFIG   -= app_bundle
 CONFIG += c++17 console
 
+QMAKE_CXX = clang++-15
+QMAKE_LINK = clang++-15
+
 LIBS += -L../../src -lhanami_common
 INCLUDEPATH += $$PWD
 INCLUDEPATH += ../../../../third-party-libs/json/include

--- a/src/libraries/hanami_config/hanami_config.pro
+++ b/src/libraries/hanami_config/hanami_config.pro
@@ -1,6 +1,9 @@
 TEMPLATE = subdirs
 CONFIG += ordered
 
+QMAKE_CXX = clang++-15
+QMAKE_LINK = clang++-15
+
 SUBDIRS = src
 
 run_tests {

--- a/src/libraries/hanami_config/src/src.pro
+++ b/src/libraries/hanami_config/src/src.pro
@@ -5,6 +5,9 @@ TEMPLATE = lib
 CONFIG += c++17
 VERSION = 0.4.0
 
+QMAKE_CXX = clang++-15
+QMAKE_LINK = clang++-15
+
 LIBS += -L../../hanami_common/src -lhanami_common
 LIBS += -L../../hanami_common/src/debug -lhanami_common
 LIBS += -L../../hanami_common/src/release -lhanami_common

--- a/src/libraries/hanami_config/tests/functional_tests/functional_tests.pro
+++ b/src/libraries/hanami_config/tests/functional_tests/functional_tests.pro
@@ -5,6 +5,9 @@ QT -= qt core gui
 CONFIG   -= app_bundle
 CONFIG += c++17 console
 
+QMAKE_CXX = clang++-15
+QMAKE_LINK = clang++-15
+
 LIBS += -L../../src -lhanami_config
 
 LIBS += -L../../../hanami_common/src -lhanami_common

--- a/src/libraries/hanami_config/tests/tests.pro
+++ b/src/libraries/hanami_config/tests/tests.pro
@@ -3,6 +3,9 @@ CONFIG += ordered
 QT -= qt core gui
 CONFIG += c++17
 
+QMAKE_CXX = clang++-15
+QMAKE_LINK = clang++-15
+
 SUBDIRS = \
     unit_tests \
     functional_tests

--- a/src/libraries/hanami_config/tests/unit_tests/unit_tests.pro
+++ b/src/libraries/hanami_config/tests/unit_tests/unit_tests.pro
@@ -5,6 +5,9 @@ QT -= qt core gui
 CONFIG   -= app_bundle
 CONFIG += c++17 console
 
+QMAKE_CXX = clang++-15
+QMAKE_LINK = clang++-15
+
 LIBS += -L../../src -lhanami_config
 
 LIBS += -L../../../hanami_common/src -lhanami_common

--- a/src/libraries/hanami_cpu/hanami_cpu.pro
+++ b/src/libraries/hanami_cpu/hanami_cpu.pro
@@ -1,6 +1,9 @@
 TEMPLATE = subdirs
 CONFIG += ordered
 
+QMAKE_CXX = clang++-15
+QMAKE_LINK = clang++-15
+
 SUBDIRS = src
 
 run_tests {

--- a/src/libraries/hanami_cpu/src/src.pro
+++ b/src/libraries/hanami_cpu/src/src.pro
@@ -5,6 +5,9 @@ TEMPLATE = lib
 CONFIG += c++17
 VERSION = 0.3.0
 
+QMAKE_CXX = clang++-15
+QMAKE_LINK = clang++-15
+
 LIBS += -L../../hanami_common/src -lhanami_common
 LIBS += -L../../hanami_common/src/debug -lhanami_common
 LIBS += -L../../hanami_common/src/release -lhanami_common

--- a/src/libraries/hanami_cpu/tests/cli_tests/cli_tests.pro
+++ b/src/libraries/hanami_cpu/tests/cli_tests/cli_tests.pro
@@ -5,6 +5,9 @@ QT -= qt core gui
 CONFIG   -= app_bundle
 CONFIG += c++17 console
 
+QMAKE_CXX = clang++-15
+QMAKE_LINK = clang++-15
+
 LIBS += -L../../src -lhanami_cpu
 
 LIBS += -L../../../hanami_common/src -lhanami_common

--- a/src/libraries/hanami_cpu/tests/tests.pro
+++ b/src/libraries/hanami_cpu/tests/tests.pro
@@ -3,6 +3,9 @@ CONFIG += ordered
 QT -= qt core gui
 CONFIG += c++17
 
+QMAKE_CXX = clang++-15
+QMAKE_LINK = clang++-15
+
 SUBDIRS = \
     cli_tests
 

--- a/src/libraries/hanami_crypto/hanami_crypto.pro
+++ b/src/libraries/hanami_crypto/hanami_crypto.pro
@@ -1,6 +1,9 @@
 TEMPLATE = subdirs
 CONFIG += ordered
 
+QMAKE_CXX = clang++-15
+QMAKE_LINK = clang++-15
+
 SUBDIRS = src
 
 run_tests {

--- a/src/libraries/hanami_crypto/src/src.pro
+++ b/src/libraries/hanami_crypto/src/src.pro
@@ -5,6 +5,9 @@ TEMPLATE = lib
 CONFIG += c++17
 VERSION = 0.2.0
 
+QMAKE_CXX = clang++-15
+QMAKE_LINK = clang++-15
+
 LIBS += -L../../hanami_common/src -lhanami_common
 LIBS += -L../../hanami_common/src/debug -lhanami_common
 LIBS += -L../../hanami_common/src/release -lhanami_common

--- a/src/libraries/hanami_crypto/tests/tests.pro
+++ b/src/libraries/hanami_crypto/tests/tests.pro
@@ -3,6 +3,9 @@ CONFIG += ordered
 QT -= qt core gui
 CONFIG += c++17
 
+QMAKE_CXX = clang++-15
+QMAKE_LINK = clang++-15
+
 SUBDIRS = \
     unit_tests
 

--- a/src/libraries/hanami_crypto/tests/unit_tests/unit_tests.pro
+++ b/src/libraries/hanami_crypto/tests/unit_tests/unit_tests.pro
@@ -5,6 +5,9 @@ QT -= qt core gui
 CONFIG   -= app_bundle
 CONFIG += c++17 console
 
+QMAKE_CXX = clang++-15
+QMAKE_LINK = clang++-15
+
 LIBS += -L../../src -lhanami_crypto
 
 LIBS += -L../../../hanami_common/src -lhanami_common

--- a/src/libraries/hanami_database/hanami_database.pro
+++ b/src/libraries/hanami_database/hanami_database.pro
@@ -1,6 +1,9 @@
 TEMPLATE = subdirs
 CONFIG += ordered
 
+QMAKE_CXX = clang++-15
+QMAKE_LINK = clang++-15
+
 SUBDIRS = src
 
 run_tests {

--- a/src/libraries/hanami_database/src/src.pro
+++ b/src/libraries/hanami_database/src/src.pro
@@ -5,6 +5,9 @@ TEMPLATE = lib
 CONFIG += c++17
 VERSION = 0.5.0
 
+QMAKE_CXX = clang++-15
+QMAKE_LINK = clang++-15
+
 LIBS += -L../../hanami_sqlite/src -lhanami_sqlite
 LIBS += -L../../hanami_sqlite/src/debug -lhanami_sqlite
 LIBS += -L../../hanami_sqlite/src/release -lhanami_sqlite

--- a/src/libraries/hanami_database/tests/functional_tests/functional_tests.pro
+++ b/src/libraries/hanami_database/tests/functional_tests/functional_tests.pro
@@ -5,6 +5,9 @@ QT -= qt core gui
 CONFIG   -= app_bundle
 CONFIG += c++17 console
 
+QMAKE_CXX = clang++-15
+QMAKE_LINK = clang++-15
+
 LIBS += -L../../src -lhanami_database
 
 LIBS += -L../../../hanami_sqlite/src -lhanami_sqlite

--- a/src/libraries/hanami_database/tests/tests.pro
+++ b/src/libraries/hanami_database/tests/tests.pro
@@ -1,7 +1,10 @@
 TEMPLATE = subdirs
 CONFIG += ordered
 QT -= qt core gui
-CONFIG += c++14
+CONFIG += c++17
+
+QMAKE_CXX = clang++-15
+QMAKE_LINK = clang++-15
 
 SUBDIRS = \
     functional_tests

--- a/src/libraries/hanami_files/hanami_files.pro
+++ b/src/libraries/hanami_files/hanami_files.pro
@@ -1,6 +1,9 @@
 TEMPLATE = subdirs
 CONFIG += ordered
 
+QMAKE_CXX = clang++-15
+QMAKE_LINK = clang++-15
+
 SUBDIRS = src
 
 run_tests {

--- a/src/libraries/hanami_files/src/src.pro
+++ b/src/libraries/hanami_files/src/src.pro
@@ -5,6 +5,9 @@ TEMPLATE = lib
 CONFIG += c++17
 VERSION = 0.1.0
 
+QMAKE_CXX = clang++-15
+QMAKE_LINK = clang++-15
+
 LIBS += -L../../hanami_common/src -lhanami_common
 LIBS += -L../../hanami_common/src/debug -lhanami_common
 LIBS += -L../../hanami_common/src/release -lhanami_common

--- a/src/libraries/hanami_files/tests/tests.pro
+++ b/src/libraries/hanami_files/tests/tests.pro
@@ -3,6 +3,9 @@ CONFIG += ordered
 QT -= qt core gui
 CONFIG += c++17
 
+QMAKE_CXX = clang++-15
+QMAKE_LINK = clang++-15
+
 SUBDIRS = \
     unit_tests
 

--- a/src/libraries/hanami_files/tests/unit_tests/unit_tests.pro
+++ b/src/libraries/hanami_files/tests/unit_tests/unit_tests.pro
@@ -5,6 +5,9 @@ QT -= qt core gui
 CONFIG   -= app_bundle
 CONFIG += c++17 console
 
+QMAKE_CXX = clang++-15
+QMAKE_LINK = clang++-15
+
 LIBS += -L../../src -lhanami_files
 
 LIBS += -L../../../hanami_common/src -lhanami_common

--- a/src/libraries/hanami_hardware/hanami_hardware.pro
+++ b/src/libraries/hanami_hardware/hanami_hardware.pro
@@ -1,6 +1,9 @@
 TEMPLATE = subdirs
 CONFIG += ordered
 
+QMAKE_CXX = clang++-15
+QMAKE_LINK = clang++-15
+
 SUBDIRS = src
 
 run_tests {

--- a/src/libraries/hanami_hardware/src/src.pro
+++ b/src/libraries/hanami_hardware/src/src.pro
@@ -5,6 +5,9 @@ TEMPLATE = lib
 CONFIG += c++17
 VERSION = 0.1.0
 
+QMAKE_CXX = clang++-15
+QMAKE_LINK = clang++-15
+
 LIBS += -L../../hanami_common/src -lhanami_common
 LIBS += -L../../hanami_common/src/debug -lhanami_common
 LIBS += -L../../hanami_common/src/release -lhanami_common

--- a/src/libraries/hanami_hardware/tests/tests.pro
+++ b/src/libraries/hanami_hardware/tests/tests.pro
@@ -3,6 +3,9 @@ CONFIG += ordered
 QT -= qt core gui
 CONFIG += c++17
 
+QMAKE_CXX = clang++-15
+QMAKE_LINK = clang++-15
+
 SUBDIRS = \
     unit_tests
 

--- a/src/libraries/hanami_hardware/tests/unit_tests/unit_tests.pro
+++ b/src/libraries/hanami_hardware/tests/unit_tests/unit_tests.pro
@@ -5,6 +5,9 @@ QT -= qt core gui
 CONFIG   -= app_bundle
 CONFIG += c++17 console
 
+QMAKE_CXX = clang++-15
+QMAKE_LINK = clang++-15
+
 LIBS += -L../../src -lhanami_hardware
 
 LIBS += -L../../../hanami_common/src -lhanami_common

--- a/src/libraries/hanami_ini/hanami_ini.pro
+++ b/src/libraries/hanami_ini/hanami_ini.pro
@@ -1,6 +1,9 @@
 TEMPLATE = subdirs
 CONFIG += ordered
 
+QMAKE_CXX = clang++-15
+QMAKE_LINK = clang++-15
+
 lexxer.file = src/lexxer.pro
 parser.file = src/parser.pro
 

--- a/src/libraries/hanami_ini/src/lexxer.pro
+++ b/src/libraries/hanami_ini/src/lexxer.pro
@@ -2,6 +2,9 @@ QT -= qt core gui
 TEMPLATE = aux
 CONFIG += c++17 staticlib
 
+QMAKE_CXX = clang++-15
+QMAKE_LINK = clang++-15
+
 LIBS += -L../../hanami_common/src -lhanami_common
 LIBS += -L../../hanami_common/src/debug -lhanami_common
 LIBS += -L../../hanami_common/src/release -lhanami_common

--- a/src/libraries/hanami_ini/src/parser.pro
+++ b/src/libraries/hanami_ini/src/parser.pro
@@ -2,6 +2,9 @@ QT -= qt core gui
 TEMPLATE = aux
 CONFIG += c++17 staticlib
 
+QMAKE_CXX = clang++-15
+QMAKE_LINK = clang++-15
+
 LIBS += -L../../hanami_common/src -lhanami_common
 LIBS += -L../../hanami_common/src/debug -lhanami_common
 LIBS += -L../../hanami_common/src/release -lhanami_common

--- a/src/libraries/hanami_ini/src/src.pro
+++ b/src/libraries/hanami_ini/src/src.pro
@@ -5,6 +5,9 @@ CONFIG += c++17
 TEMPLATE = lib
 VERSION = 0.5.1
 
+QMAKE_CXX = clang++-15
+QMAKE_LINK = clang++-15
+
 LIBS += -L../../hanami_common/src -lhanami_common
 LIBS += -L../../hanami_common/src/debug -lhanami_common
 LIBS += -L../../hanami_common/src/release -lhanami_common

--- a/src/libraries/hanami_ini/tests/tests.pro
+++ b/src/libraries/hanami_ini/tests/tests.pro
@@ -3,6 +3,9 @@ CONFIG += ordered
 QT -= qt core gui
 CONFIG += c++17
 
+QMAKE_CXX = clang++-15
+QMAKE_LINK = clang++-15
+
 SUBDIRS = \
     unit_tests
 

--- a/src/libraries/hanami_ini/tests/unit_tests/unit_tests.pro
+++ b/src/libraries/hanami_ini/tests/unit_tests/unit_tests.pro
@@ -5,6 +5,9 @@ QT -= qt core gui
 CONFIG   -= app_bundle
 CONFIG += c++17 console
 
+QMAKE_CXX = clang++-15
+QMAKE_LINK = clang++-15
+
 LIBS += -L../../src -lhanami_ini
 
 LIBS += -L../../../hanami_common/src -lhanami_common

--- a/src/libraries/hanami_policies/hanami_policies.pro
+++ b/src/libraries/hanami_policies/hanami_policies.pro
@@ -1,6 +1,9 @@
 TEMPLATE = subdirs
 CONFIG += ordered
 
+QMAKE_CXX = clang++-15
+QMAKE_LINK = clang++-15
+
 lexxer.file = src/lexxer.pro
 parser.file = src/parser.pro
 

--- a/src/libraries/hanami_policies/src/lexxer.pro
+++ b/src/libraries/hanami_policies/src/lexxer.pro
@@ -2,6 +2,9 @@ QT -= qt core gui
 TEMPLATE = aux
 CONFIG += c++17 staticlib
 
+QMAKE_CXX = clang++-15
+QMAKE_LINK = clang++-15
+
 LIBS += -L../../hanami_common/src -lhanami_common
 LIBS += -L../../hanami_common/src/debug -lhanami_common
 LIBS += -L../../hanami_common/src/release -lhanami_common

--- a/src/libraries/hanami_policies/src/parser.pro
+++ b/src/libraries/hanami_policies/src/parser.pro
@@ -2,6 +2,9 @@ QT -= qt core gui
 TEMPLATE = aux
 CONFIG += c++17 staticlib
 
+QMAKE_CXX = clang++-15
+QMAKE_LINK = clang++-15
+
 LIBS += -L../../hanami_common/src -lhanami_common
 LIBS += -L../../hanami_common/src/debug -lhanami_common
 LIBS += -L../../hanami_common/src/release -lhanami_common

--- a/src/libraries/hanami_policies/src/src.pro
+++ b/src/libraries/hanami_policies/src/src.pro
@@ -5,6 +5,9 @@ TEMPLATE = lib
 CONFIG += c++17
 VERSION = 0.1.0
 
+QMAKE_CXX = clang++-15
+QMAKE_LINK = clang++-15
+
 LIBS += -L../../hanami_args/src -lhanami_args
 LIBS += -L../../hanami_args/src/debug -lhanami_args
 LIBS += -L../../hanami_args/src/release -lhanami_args

--- a/src/libraries/hanami_policies/tests/tests.pro
+++ b/src/libraries/hanami_policies/tests/tests.pro
@@ -3,6 +3,9 @@ CONFIG += ordered
 QT -= qt core gui
 CONFIG += c++17
 
+QMAKE_CXX = clang++-15
+QMAKE_LINK = clang++-15
+
 SUBDIRS = \
     unit_tests
 

--- a/src/libraries/hanami_policies/tests/unit_tests/unit_tests.pro
+++ b/src/libraries/hanami_policies/tests/unit_tests/unit_tests.pro
@@ -5,6 +5,9 @@ QT -= qt core gui
 CONFIG   -= app_bundle
 CONFIG += c++17 console
 
+QMAKE_CXX = clang++-15
+QMAKE_LINK = clang++-15
+
 LIBS += -L../../src -lhanami_policies
 
 LIBS += -L../../../hanami_common/src -lhanami_common

--- a/src/libraries/hanami_sqlite/hanami_sqlite.pro
+++ b/src/libraries/hanami_sqlite/hanami_sqlite.pro
@@ -1,6 +1,9 @@
 TEMPLATE = subdirs
 CONFIG += ordered
 
+QMAKE_CXX = clang++-15
+QMAKE_LINK = clang++-15
+
 SUBDIRS = src
 
 run_tests {

--- a/src/libraries/hanami_sqlite/src/src.pro
+++ b/src/libraries/hanami_sqlite/src/src.pro
@@ -5,6 +5,9 @@ TEMPLATE = lib
 CONFIG += c++17
 VERSION = 0.3.0
 
+QMAKE_CXX = clang++-15
+QMAKE_LINK = clang++-15
+
 LIBS += -L../../hanami_common/src -lhanami_common
 LIBS += -L../../hanami_common/src/debug -lhanami_common
 LIBS += -L../../hanami_common/src/release -lhanami_common

--- a/src/libraries/hanami_sqlite/tests/tests.pro
+++ b/src/libraries/hanami_sqlite/tests/tests.pro
@@ -3,6 +3,9 @@ CONFIG += ordered
 QT -= qt core gui
 CONFIG += c++17
 
+QMAKE_CXX = clang++-15
+QMAKE_LINK = clang++-15
+
 SUBDIRS = \
     unit_tests
 

--- a/src/libraries/hanami_sqlite/tests/unit_tests/unit_tests.pro
+++ b/src/libraries/hanami_sqlite/tests/unit_tests/unit_tests.pro
@@ -5,6 +5,9 @@ QT -= qt core gui
 CONFIG   -= app_bundle
 CONFIG += c++17 console
 
+QMAKE_CXX = clang++-15
+QMAKE_LINK = clang++-15
+
 LIBS += -L../../src -lhanami_sqlite
 
 LIBS += -L../../../hanami_common/src -lhanami_common

--- a/src/libraries/libraries.pro
+++ b/src/libraries/libraries.pro
@@ -3,6 +3,9 @@ CONFIG += ordered
 QT -= qt core gui
 CONFIG += c++17
 
+QMAKE_CXX = clang++-15
+QMAKE_LINK = clang++-15
+
 SUBDIRS =  hanami_common
 SUBDIRS += hanami_crypto
 SUBDIRS += hanami_ini

--- a/src/sdk/cpp/hanami_sdk/hanami_sdk.pro
+++ b/src/sdk/cpp/hanami_sdk/hanami_sdk.pro
@@ -1,7 +1,10 @@
 TEMPLATE = subdirs
 CONFIG += ordered
 QT -= qt core gui
-CONFIG += c++14
+CONFIG += c++17
+
+QMAKE_CXX = clang++-15
+QMAKE_LINK = clang++-15
 
 SUBDIRS = src
 

--- a/src/sdk/cpp/hanami_sdk/src/src.pro
+++ b/src/sdk/cpp/hanami_sdk/src/src.pro
@@ -5,6 +5,9 @@ CONFIG += c++17
 TEMPLATE = lib
 VERSION = 0.3.1
 
+QMAKE_CXX = clang++-15
+QMAKE_LINK = clang++-15
+
 LIBS += -L../../../../libraries/hanami_common/src -lhanami_common
 LIBS += -L../../../../libraries/hanami_common/src/debug -lhanami_common
 LIBS += -L../../../../libraries/hanami_common/src/release -lhanami_common

--- a/src/sdk/cpp/hanami_sdk/tests/tests.pro
+++ b/src/sdk/cpp/hanami_sdk/tests/tests.pro
@@ -4,4 +4,7 @@ QT -= qt core gui
 CONFIG += c++17
 
 
+QMAKE_CXX = clang++-15
+QMAKE_LINK = clang++-15
+
 tests.depends = src

--- a/src/testing/SDK_API_Testing/SDK_API_Testing.pro
+++ b/src/testing/SDK_API_Testing/SDK_API_Testing.pro
@@ -4,6 +4,9 @@ TARGET = SDK_API_Testing
 CONFIG += console c++17
 CONFIG -= app_bundle
 
+QMAKE_CXX = clang++-15
+QMAKE_LINK = clang++-15
+
 LIBS += -L../../sdk/cpp/hanami_sdk/src -lhanami_sdk
 LIBS += -L../../sdk/cpp/hanami_sdk/src/debug -lhanami_sdk
 LIBS += -L../../sdk/cpp/hanami_sdk/src/release -lhanami_sdk

--- a/src/testing/testing.pro
+++ b/src/testing/testing.pro
@@ -3,4 +3,7 @@ CONFIG += ordered
 QT -= qt core gui
 CONFIG += c++17
 
+QMAKE_CXX = clang++-15
+QMAKE_LINK = clang++-15
+
 SUBDIRS += SDK_API_Testing


### PR DESCRIPTION
## Pull Request

### Description

Updated the build-process to use clange++
instead of g++.

### Related Issues
- #195 

### How it was tested?

- updated ci-pipeline
