### PR TITLE
Fix (#210): fix cuda-problem with standard toolkit

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,18 +85,8 @@ If you need help to setup things, have a question or something like this, feel f
 
 **Required packages:**
 
-- Ubuntu 22.04:
-
 ```
-sudo apt-get install -y git ssh gcc g++ clang-format-15 make qt5-qmake bison flex libssl-dev libcrypto++-dev libboost1.74-dev uuid-dev  libsqlite3-dev protobuf-compiler 
-```
-
-CUDA 12 is necessary, which is not in the standard apt-repositories below ubuntu 23.04. So in case it should be installed on 22.04, CUDA has to be installed manually with the manual: https://docs.nvidia.com/cuda/cuda-installation-guide-linux/index.html
-
-- Ubuntu 23.04
-
-```
-sudo apt-get install -y git ssh clang++-15 clang-format-15 make qt5-qmake bison flex libssl-dev libcrypto++-dev libboost1.74-dev uuid-dev  libsqlite3-dev protobuf-compiler nvidia-cuda-toolkit
+sudo apt-get install -y git ssh gcc g++ clang-15 clang-format-15 make qt5-qmake bison flex libssl-dev libcrypto++-dev libboost1.74-dev uuid-dev  libsqlite3-dev protobuf-compiler nvidia-cuda-toolkit
 ```
 
 **Clone repo with:**

--- a/build/docker/Dockerfile
+++ b/build/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:23.04
+FROM ubuntu:22.04
 
 RUN apt-get update && \
     apt-get install -y clang-15 \

--- a/build/docker/files/Dockerfile_hanami_base
+++ b/build/docker/files/Dockerfile_hanami_base
@@ -1,6 +1,6 @@
-FROM nvidia/cuda:12.2.0-base-ubuntu22.04
+FROM ubuntu22.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && \
-    apt-get install -y openssl libuuid1 libcrypto++8 libsqlite3-0 libprotobuf23 libboost1.74;
+    apt-get install -y openssl libuuid1 libcrypto++8 libsqlite3-0 libprotobuf23 libboost1.74 libcudart11.0;

--- a/docs/other/dependencies.md
+++ b/docs/other/dependencies.md
@@ -24,10 +24,6 @@ Installed packages under the actual used Ubuntu 23.04
 | g++  | C++-compiler |
 | nvidia-cuda-toolkit | Libraries and compiler for the CUDA-Kernel |
 
-!!! info
-
-    CUDA 12 is necessary, which is not in the standard apt-repositories below ubuntu 23.04. So in case it should be installed on 22.04, CUDA has to be installed manually with the manual: https://docs.nvidia.com/cuda/cuda-installation-guide-linux/index.html
-
 ### Submodules
 
 | name | License | Purpose |
@@ -45,7 +41,7 @@ Installed packages under the actual used Ubuntu 23.04
 | libsqlite3-0  | Library to interact with the SQLite3 databases | 
 | libprotobuf23 | Runtime-library for protobuffers | 
 | libboost1.74 | Provides the Beast-library of Boost, which is used for the REST-API within the Torii |
-| libcudart12.0 | Runtime-library for CUDA | 
+| libcudart11.0 | Runtime-library for CUDA | 
 
 ## Overview
 

--- a/src/Hanami/src/core/processing/objects.h
+++ b/src/Hanami/src/core/processing/objects.h
@@ -27,7 +27,6 @@
 #include <stdint.h>
 #include <uuid/uuid.h>
 
-#include <algorithm>
 #include <cstdlib>
 #include <string>
 


### PR DESCRIPTION
## Pull Request

### Description

Fixed the compile-error when trying to compile the programm on ubuntu 22.04 and below with the cude-
toolkit from the official apt-repositories.
Also updated the requirements within the documentation.


### Related Issues

- #210 

### How it was tested?

- ci-pipeline
