### PR TITLE
Fix (#228): fix error-log

### DIFF
--- a/src/Hanami/src/api/endpoint_processing/http_processing/response_builds.h
+++ b/src/Hanami/src/api/endpoint_processing/http_processing/response_builds.h
@@ -71,11 +71,14 @@ invalid_ResponseBuild(http::response<http::dynamic_body>& httpResp, Hanami::Erro
  */
 bool
 internalError_ResponseBuild(http::response<http::dynamic_body>& httpResp,
+                            const std::string& userId,
+                            json& inputValuesJson,
                             Hanami::ErrorContainer& error)
 {
+    inputValuesJson.erase("password");
     httpResp.result(http::status::internal_server_error);
     httpResp.set(http::field::content_type, "text/plain");
-    LOG_ERROR(error);
+    LOG_ERROR(error, userId, inputValuesJson.dump());
     return false;
 }
 

--- a/src/Hanami/src/api/http/v1/logs/get_error_log.cpp
+++ b/src/Hanami/src/api/http/v1/logs/get_error_log.cpp
@@ -89,7 +89,7 @@ GetErrorLog::runTask(BlossomIO& blossomIO,
         return false;
     }
 
-    const std::string userId = blossomIO.input["user_id"];
+    const std::string userId = blossomIO.input.value("user_id", "");
 
     // get data from table
     Hanami::TableItem table;

--- a/src/Hanami/src/main.cpp
+++ b/src/Hanami/src/main.cpp
@@ -41,6 +41,16 @@
 
 #include <thread>
 
+void
+handleErrorCallback(const std::string& errorMessage,
+                    const std::string& userId,
+                    const std::string& values)
+{
+    ErrorContainer error;
+    ErrorLogTable::getInstance()->addErrorLogEntry(
+        getDatetime(), userId, "", "", values, errorMessage, error);
+}
+
 int
 main(int argc, char* argv[])
 {
@@ -133,6 +143,7 @@ main(int argc, char* argv[])
     }
 
     // init logger
+    Hanami::setErrorLogCallback(&handleErrorCallback);
     Hanami::initConsoleLogger(enableDebug);
     Hanami::initFileLogger(logPath, "hanami", enableDebug);
 

--- a/src/libraries/hanami_common/include/hanami_common/logger.h
+++ b/src/libraries/hanami_common/include/hanami_common/logger.h
@@ -108,12 +108,16 @@ bool setDebugFlag(const bool debugLog);
 
 bool LOG_debug(const std::string& message);
 bool LOG_warning(const std::string& message);
-bool LOG_error(ErrorContainer& container);
+bool LOG_error(ErrorContainer& container,
+               const std::string& userId = "",
+               const std::string& values = "");
 bool LOG_info(const std::string& message, const std::string& color = WHITE_COLOR);
 
 void closeLogFile();
 
-void setErrorLogCallback(void (*handleError)(const std::string&));
+void setErrorLogCallback(void (*handleError)(const std::string&,
+                                             const std::string&,
+                                             const std::string&));
 
 //==================================================================================================
 
@@ -128,7 +132,9 @@ class Logger
                         const bool debugLog);
     bool initConsoleLogger(const bool debugLog);
     bool setDebugFlag(const bool debugLog);
-    void setErrorLogCallback(void (*handleError)(const std::string&));
+    void setErrorLogCallback(void (*handleError)(const std::string&,
+                                                 const std::string&,
+                                                 const std::string&));
 
     void closeLogFile();
 
@@ -139,7 +145,7 @@ class Logger
 
     std::string m_filePath = "";
     bool m_debugLog = false;
-    void (*m_handleError)(const std::string&);
+    void (*m_handleError)(const std::string&, const std::string&, const std::string&);
 
     static Hanami::Logger* m_logger;
 

--- a/src/libraries/hanami_common/src/logger.cpp
+++ b/src/libraries/hanami_common/src/logger.cpp
@@ -63,7 +63,7 @@ setDebugFlag(const bool debugLog)
  *        to be set to avoid seg-faults.
  */
 void
-defaultErrorCallback(const std::string&)
+defaultErrorCallback(const std::string&, const std::string&, const std::string&)
 {
 }
 
@@ -89,7 +89,7 @@ LOG_warning(const std::string& message)
  * @brief write error-message to logfile
  */
 bool
-LOG_error(ErrorContainer& container)
+LOG_error(ErrorContainer& container, const std::string& userId, const std::string& values)
 {
     if (container._alreadyPrinted) {
         return true;
@@ -97,7 +97,7 @@ LOG_error(ErrorContainer& container)
 
     const std::string errorMessage = container.toString();
     const bool ret = Logger::m_logger->logData(errorMessage, "ERROR", RED_COLOR);
-    Logger::m_logger->m_handleError(errorMessage);
+    Logger::m_logger->m_handleError(errorMessage, userId, values);
     if (ret) {
         container._alreadyPrinted = true;
     }
@@ -224,7 +224,9 @@ Logger::setDebugFlag(const bool debugLog)
  * @brief set callback for error-messages
  */
 void
-Logger::setErrorLogCallback(void (*handleError)(const std::string&))
+Logger::setErrorLogCallback(void (*handleError)(const std::string&,
+                                                const std::string&,
+                                                const std::string&))
 {
     m_handleError = handleError;
 }
@@ -315,7 +317,7 @@ Logger::getDatetime()
  * @brief set callback for error-messages
  */
 void
-setErrorLogCallback(void (*handleError)(const std::string&))
+setErrorLogCallback(void (*handleError)(const std::string&, const std::string&, const std::string&))
 {
     Logger::m_logger->setErrorLogCallback(handleError);
 }

--- a/src/libraries/hanami_database/src/sql_table.cpp
+++ b/src/libraries/hanami_database/src/sql_table.cpp
@@ -133,7 +133,6 @@ SqlTable::insertToDb(json& values, ErrorContainer& error)
         if (values.contains(entry.name) == false && entry.allowNull == false) {
             error.addMeesage("insert into dabase failed, because '" + entry.name
                              + "' is required, but missing in the input-values.");
-            LOG_ERROR(error);
             return false;
         }
         if (values[entry.name].is_string()) {
@@ -146,7 +145,6 @@ SqlTable::insertToDb(json& values, ErrorContainer& error)
 
     // build and run insert-command
     if (m_db->execSqlCommand(&resultItem, createInsertQuery(dbValues), error) == false) {
-        LOG_ERROR(error);
         return false;
     }
 


### PR DESCRIPTION
## Pull Request

### Description

There were no error-messages written into the
central error-log. This became broken while
merging the old microservices and wasn't tested
since then. This was fixed now.
<!-- A concise description of the content of the pull-request -->

### Related Issues

- #228 
<!-- In context of which issues the changes of this pull request were created. -->

### How it was tested?

- manually test with python-script against the error-log endpoint
<!-- What parts and how they were tested -->
