### PR TITLE
Fixed (#254): fixed release-build

### DIFF
--- a/src/Hanami/src/api/http/v1/blossom_initializing.h
+++ b/src/Hanami/src/api/http/v1/blossom_initializing.h
@@ -88,25 +88,25 @@ initClusterBlossoms()
     const std::string group = "Cluster";
     HttpProcessing* httpProcessing = HanamiRoot::httpServer->httpProcessing;
 
-    assert(httpProcessing->addBlossom(group, "create", new CreateCluster()));
+    httpProcessing->addBlossom(group, "create", new CreateCluster());
     httpProcessing->addEndpoint("v1/cluster", Hanami::POST_TYPE, BLOSSOM_TYPE, group, "create");
 
-    assert(httpProcessing->addBlossom(group, "show", new ShowCluster()));
+    httpProcessing->addBlossom(group, "show", new ShowCluster());
     httpProcessing->addEndpoint("v1/cluster", Hanami::GET_TYPE, BLOSSOM_TYPE, group, "show");
 
-    assert(httpProcessing->addBlossom(group, "list", new ListCluster()));
+    httpProcessing->addBlossom(group, "list", new ListCluster());
     httpProcessing->addEndpoint("v1/cluster/all", Hanami::GET_TYPE, BLOSSOM_TYPE, group, "list");
 
-    assert(httpProcessing->addBlossom(group, "delete", new DeleteCluster()));
+    httpProcessing->addBlossom(group, "delete", new DeleteCluster());
     httpProcessing->addEndpoint("v1/cluster", Hanami::DELETE_TYPE, BLOSSOM_TYPE, group, "delete");
 
-    assert(httpProcessing->addBlossom(group, "save", new SaveCluster()));
+    httpProcessing->addBlossom(group, "save", new SaveCluster());
     httpProcessing->addEndpoint("v1/cluster/save", Hanami::POST_TYPE, BLOSSOM_TYPE, group, "save");
 
-    assert(httpProcessing->addBlossom(group, "load", new LoadCluster()));
+    httpProcessing->addBlossom(group, "load", new LoadCluster());
     httpProcessing->addEndpoint("v1/cluster/load", Hanami::POST_TYPE, BLOSSOM_TYPE, group, "load");
 
-    assert(httpProcessing->addBlossom(group, "set_mode", new SetClusterMode()));
+    httpProcessing->addBlossom(group, "set_mode", new SetClusterMode());
     httpProcessing->addEndpoint(
         "v1/cluster/set_mode", Hanami::PUT_TYPE, BLOSSOM_TYPE, group, "set_mode");
 }
@@ -120,16 +120,16 @@ initTaskBlossoms()
     const std::string group = "Task";
     HttpProcessing* httpProcessing = HanamiRoot::httpServer->httpProcessing;
 
-    assert(httpProcessing->addBlossom(group, "create", new CreateTask()));
+    httpProcessing->addBlossom(group, "create", new CreateTask());
     httpProcessing->addEndpoint("v1/task", Hanami::POST_TYPE, BLOSSOM_TYPE, group, "create");
 
-    assert(httpProcessing->addBlossom(group, "show", new ShowTask()));
+    httpProcessing->addBlossom(group, "show", new ShowTask());
     httpProcessing->addEndpoint("v1/task", Hanami::GET_TYPE, BLOSSOM_TYPE, group, "show");
 
-    assert(httpProcessing->addBlossom(group, "list", new ListTask()));
+    httpProcessing->addBlossom(group, "list", new ListTask());
     httpProcessing->addEndpoint("v1/task/all", Hanami::GET_TYPE, BLOSSOM_TYPE, group, "list");
 
-    assert(httpProcessing->addBlossom(group, "delete", new DeleteTask()));
+    httpProcessing->addBlossom(group, "delete", new DeleteTask());
     httpProcessing->addEndpoint("v1/task", Hanami::DELETE_TYPE, BLOSSOM_TYPE, group, "delete");
 }
 
@@ -142,37 +142,37 @@ dataSetBlossoms()
     const std::string group = "Data Set";
     HttpProcessing* httpProcessing = HanamiRoot::httpServer->httpProcessing;
 
-    assert(httpProcessing->addBlossom(group, "create_mnist", new CreateMnistDataSet()));
+    httpProcessing->addBlossom(group, "create_mnist", new CreateMnistDataSet());
     httpProcessing->addEndpoint(
         "v1/mnist/dataset", Hanami::POST_TYPE, BLOSSOM_TYPE, group, "create_mnist");
 
-    assert(httpProcessing->addBlossom(group, "finalize_mnist", new FinalizeMnistDataSet()));
+    httpProcessing->addBlossom(group, "finalize_mnist", new FinalizeMnistDataSet());
     httpProcessing->addEndpoint(
         "v1/mnist/dataset", Hanami::PUT_TYPE, BLOSSOM_TYPE, group, "finalize_mnist");
 
-    assert(httpProcessing->addBlossom(group, "create_csv", new CreateCsvDataSet()));
+    httpProcessing->addBlossom(group, "create_csv", new CreateCsvDataSet());
     httpProcessing->addEndpoint(
         "v1/csv/dataset", Hanami::POST_TYPE, BLOSSOM_TYPE, group, "create_csv");
 
-    assert(httpProcessing->addBlossom(group, "finalize_csv", new FinalizeCsvDataSet()));
+    httpProcessing->addBlossom(group, "finalize_csv", new FinalizeCsvDataSet());
     httpProcessing->addEndpoint(
         "v1/csv/dataset", Hanami::PUT_TYPE, BLOSSOM_TYPE, group, "finalize_csv");
 
-    assert(httpProcessing->addBlossom(group, "check", new CheckDataSet()));
+    httpProcessing->addBlossom(group, "check", new CheckDataSet());
     httpProcessing->addEndpoint(
         "v1/dataset/check", Hanami::POST_TYPE, BLOSSOM_TYPE, group, "check");
 
-    assert(httpProcessing->addBlossom(group, "progress", new GetProgressDataSet()));
+    httpProcessing->addBlossom(group, "progress", new GetProgressDataSet());
     httpProcessing->addEndpoint(
         "v1/dataset/progress", Hanami::GET_TYPE, BLOSSOM_TYPE, group, "progress");
 
-    assert(httpProcessing->addBlossom(group, "get", new GetDataSet()));
+    httpProcessing->addBlossom(group, "get", new GetDataSet());
     httpProcessing->addEndpoint("v1/dataset", Hanami::GET_TYPE, BLOSSOM_TYPE, group, "get");
 
-    assert(httpProcessing->addBlossom(group, "delete", new DeleteDataSet()));
+    httpProcessing->addBlossom(group, "delete", new DeleteDataSet());
     httpProcessing->addEndpoint("v1/dataset", Hanami::DELETE_TYPE, BLOSSOM_TYPE, group, "delete");
 
-    assert(httpProcessing->addBlossom(group, "list", new ListDataSet()));
+    httpProcessing->addBlossom(group, "list", new ListDataSet());
     httpProcessing->addEndpoint("v1/dataset/all", Hanami::GET_TYPE, BLOSSOM_TYPE, group, "list");
 }
 
@@ -185,14 +185,14 @@ clusterCheckpointBlossoms()
     const std::string group = "Checkpoint";
     HttpProcessing* httpProcessing = HanamiRoot::httpServer->httpProcessing;
 
-    assert(httpProcessing->addBlossom(group, "get", new GetCheckpoint()));
+    httpProcessing->addBlossom(group, "get", new GetCheckpoint());
     httpProcessing->addEndpoint("v1/checkpoint", Hanami::GET_TYPE, BLOSSOM_TYPE, group, "get");
 
-    assert(httpProcessing->addBlossom(group, "delete", new DeleteCheckpoint()));
+    httpProcessing->addBlossom(group, "delete", new DeleteCheckpoint());
     httpProcessing->addEndpoint(
         "v1/checkpoint", Hanami::DELETE_TYPE, BLOSSOM_TYPE, group, "delete");
 
-    assert(httpProcessing->addBlossom(group, "list", new ListCheckpoint()));
+    httpProcessing->addBlossom(group, "list", new ListCheckpoint());
     httpProcessing->addEndpoint("v1/checkpoint/all", Hanami::GET_TYPE, BLOSSOM_TYPE, group, "list");
 }
 
@@ -205,14 +205,14 @@ resultBlossoms()
     const std::string group = "Request-Result";
     HttpProcessing* httpProcessing = HanamiRoot::httpServer->httpProcessing;
 
-    assert(httpProcessing->addBlossom(group, "get", new GetRequestResult()));
+    httpProcessing->addBlossom(group, "get", new GetRequestResult());
     httpProcessing->addEndpoint("v1/request_result", Hanami::GET_TYPE, BLOSSOM_TYPE, group, "get");
 
-    assert(httpProcessing->addBlossom(group, "list", new ListRequestResult()));
+    httpProcessing->addBlossom(group, "list", new ListRequestResult());
     httpProcessing->addEndpoint(
         "v1/request_result/all", Hanami::GET_TYPE, BLOSSOM_TYPE, group, "list");
 
-    assert(httpProcessing->addBlossom(group, "delete", new DeleteRequestResult()));
+    httpProcessing->addBlossom(group, "delete", new DeleteRequestResult());
     httpProcessing->addEndpoint(
         "v1/request_result", Hanami::DELETE_TYPE, BLOSSOM_TYPE, group, "delete");
 }
@@ -226,11 +226,11 @@ logsBlossoms()
     const std::string group = "Logs";
     HttpProcessing* httpProcessing = HanamiRoot::httpServer->httpProcessing;
 
-    assert(httpProcessing->addBlossom(group, "get_audit_log", new GetAuditLog()));
+    httpProcessing->addBlossom(group, "get_audit_log", new GetAuditLog());
     httpProcessing->addEndpoint(
         "v1/audit_log", Hanami::GET_TYPE, BLOSSOM_TYPE, group, "get_audit_log");
 
-    assert(httpProcessing->addBlossom(group, "get_error_log", new GetErrorLog()));
+    httpProcessing->addBlossom(group, "get_error_log", new GetErrorLog());
     httpProcessing->addEndpoint(
         "v1/error_log", Hanami::GET_TYPE, BLOSSOM_TYPE, group, "get_error_log");
 }
@@ -244,13 +244,13 @@ tokenBlossomes()
     const std::string group = "Token";
     HttpProcessing* httpProcessing = HanamiRoot::httpServer->httpProcessing;
 
-    assert(httpProcessing->addBlossom(group, "create", new CreateToken()));
+    httpProcessing->addBlossom(group, "create", new CreateToken());
     httpProcessing->addEndpoint("v1/token", Hanami::POST_TYPE, BLOSSOM_TYPE, group, "create");
 
-    assert(httpProcessing->addBlossom(group, "renew", new RenewToken()));
+    httpProcessing->addBlossom(group, "renew", new RenewToken());
     httpProcessing->addEndpoint("v1/token", Hanami::PUT_TYPE, BLOSSOM_TYPE, group, "renew");
 
-    assert(httpProcessing->addBlossom(group, "validate", new ValidateAccess()));
+    httpProcessing->addBlossom(group, "validate", new ValidateAccess());
     httpProcessing->addEndpoint("v1/auth", Hanami::GET_TYPE, BLOSSOM_TYPE, group, "validate");
 }
 
@@ -263,32 +263,31 @@ userBlossomes()
     const std::string userGroup = "User";
     HttpProcessing* httpProcessing = HanamiRoot::httpServer->httpProcessing;
 
-    assert(httpProcessing->addBlossom(userGroup, "create", new CreateUser()));
+    httpProcessing->addBlossom(userGroup, "create", new CreateUser());
     httpProcessing->addEndpoint("v1/user", Hanami::POST_TYPE, BLOSSOM_TYPE, userGroup, "create");
 
-    assert(httpProcessing->addBlossom(userGroup, "get", new GetUser()));
+    httpProcessing->addBlossom(userGroup, "get", new GetUser());
     httpProcessing->addEndpoint("v1/user", Hanami::GET_TYPE, BLOSSOM_TYPE, userGroup, "get");
 
-    assert(httpProcessing->addBlossom(userGroup, "list", new ListUsers()));
+    httpProcessing->addBlossom(userGroup, "list", new ListUsers());
     httpProcessing->addEndpoint("v1/user/all", Hanami::GET_TYPE, BLOSSOM_TYPE, userGroup, "list");
 
-    assert(httpProcessing->addBlossom(userGroup, "delete", new DeleteUser()));
+    httpProcessing->addBlossom(userGroup, "delete", new DeleteUser());
     httpProcessing->addEndpoint("v1/user", Hanami::DELETE_TYPE, BLOSSOM_TYPE, userGroup, "delete");
 
     const std::string userProjectGroup = "User-Projects";
 
-    assert(httpProcessing->addBlossom(userProjectGroup, "add_project", new AddProjectToUser()));
+    httpProcessing->addBlossom(userProjectGroup, "add_project", new AddProjectToUser());
     httpProcessing->addEndpoint(
         "v1/user/project", Hanami::POST_TYPE, BLOSSOM_TYPE, userProjectGroup, "add_project");
 
-    assert(httpProcessing->addBlossom(
-        userProjectGroup, "remove_project", new RemoveProjectFromUser()));
+    httpProcessing->addBlossom(userProjectGroup, "remove_project", new RemoveProjectFromUser());
     httpProcessing->addEndpoint(
         "v1/user/project", Hanami::DELETE_TYPE, BLOSSOM_TYPE, userProjectGroup, "remove_project");
 
     // TODO: move ListUserProjects-class in user-directory
-    assert(
-        httpProcessing->addBlossom(userProjectGroup, "list_user_projects", new ListUserProjects()));
+
+    httpProcessing->addBlossom(userProjectGroup, "list_user_projects", new ListUserProjects());
     httpProcessing->addEndpoint(
         "v1/user/project", Hanami::GET_TYPE, BLOSSOM_TYPE, userProjectGroup, "list_user_projects");
 }
@@ -302,16 +301,16 @@ projectBlossomes()
     const std::string group = "Project";
     HttpProcessing* httpProcessing = HanamiRoot::httpServer->httpProcessing;
 
-    assert(httpProcessing->addBlossom(group, "create", new CreateProject()));
+    httpProcessing->addBlossom(group, "create", new CreateProject());
     httpProcessing->addEndpoint("v1/project", Hanami::POST_TYPE, BLOSSOM_TYPE, group, "create");
 
-    assert(httpProcessing->addBlossom(group, "get", new GetProject()));
+    httpProcessing->addBlossom(group, "get", new GetProject());
     httpProcessing->addEndpoint("v1/project", Hanami::GET_TYPE, BLOSSOM_TYPE, group, "get");
 
-    assert(httpProcessing->addBlossom(group, "list", new ListProjects()));
+    httpProcessing->addBlossom(group, "list", new ListProjects());
     httpProcessing->addEndpoint("v1/project/all", Hanami::GET_TYPE, BLOSSOM_TYPE, group, "list");
 
-    assert(httpProcessing->addBlossom(group, "delete", new DeleteProject()));
+    httpProcessing->addBlossom(group, "delete", new DeleteProject());
     httpProcessing->addEndpoint("v1/project", Hanami::DELETE_TYPE, BLOSSOM_TYPE, group, "delete");
 }
 
@@ -324,21 +323,19 @@ measuringBlossomes()
     const std::string group = "Measurements";
     HttpProcessing* httpProcessing = HanamiRoot::httpServer->httpProcessing;
 
-    assert(httpProcessing->addBlossom(group, "get_power_consumption", new PowerConsumption()));
-    assert(httpProcessing->addEndpoint(
-        "v1/power_consumption", Hanami::GET_TYPE, BLOSSOM_TYPE, group, "get_power_consumption"));
+    httpProcessing->addBlossom(group, "get_power_consumption", new PowerConsumption());
+    httpProcessing->addEndpoint(
+        "v1/power_consumption", Hanami::GET_TYPE, BLOSSOM_TYPE, group, "get_power_consumption");
 
-    assert(httpProcessing->addBlossom(group, "get_speed", new Speed()));
-    assert(httpProcessing->addEndpoint(
-        "v1/speed", Hanami::GET_TYPE, BLOSSOM_TYPE, group, "get_speed"));
+    httpProcessing->addBlossom(group, "get_speed", new Speed());
+    httpProcessing->addEndpoint("v1/speed", Hanami::GET_TYPE, BLOSSOM_TYPE, group, "get_speed");
 
-    assert(
-        httpProcessing->addBlossom(group, "get_temperature_production", new ThermalProduction()));
-    assert(httpProcessing->addEndpoint("v1/temperature_production",
-                                       Hanami::GET_TYPE,
-                                       BLOSSOM_TYPE,
-                                       group,
-                                       "get_temperature_production"));
+    httpProcessing->addBlossom(group, "get_temperature_production", new ThermalProduction());
+    httpProcessing->addEndpoint("v1/temperature_production",
+                                Hanami::GET_TYPE,
+                                BLOSSOM_TYPE,
+                                group,
+                                "get_temperature_production");
 }
 
 /**
@@ -360,13 +357,13 @@ initBlossoms()
 
     HttpProcessing* httpProcessing = HanamiRoot::httpServer->httpProcessing;
 
-    assert(httpProcessing->addBlossom("System", "get_info", new GetSystemInfo()));
-    assert(httpProcessing->addEndpoint(
-        "v1/system_info", Hanami::GET_TYPE, BLOSSOM_TYPE, "System", "get_info"));
+    httpProcessing->addBlossom("System", "get_info", new GetSystemInfo());
+    httpProcessing->addEndpoint(
+        "v1/system_info", Hanami::GET_TYPE, BLOSSOM_TYPE, "System", "get_info");
 
-    assert(httpProcessing->addBlossom("Threading", "get_mapping", new GetThreadMapping()));
-    assert(httpProcessing->addEndpoint(
-        "v1/threading", Hanami::GET_TYPE, BLOSSOM_TYPE, "Threading", "get_mapping"));
+    httpProcessing->addBlossom("Threading", "get_mapping", new GetThreadMapping());
+    httpProcessing->addEndpoint(
+        "v1/threading", Hanami::GET_TYPE, BLOSSOM_TYPE, "Threading", "get_mapping");
 }
 
 #endif  // HANAMI_BLOSSOM_INITIALIZING_H


### PR DESCRIPTION
## Pull Request

### Description

The new cmake build had removed all asserts from the code when comipling in release-mode. This broke the initializing of the api-endpoints. The asserts were now removed from the code.

### Related Issues

- #254 

### How it was tested?

- sdk-api-test
- ci-pipeline
