### PR TITLE
Fix (#280): fix measurements for virtual machines

### DIFF
--- a/src/libraries/hanami_hardware/include/hanami_hardware/cpu_thread.h
+++ b/src/libraries/hanami_hardware/include/hanami_hardware/cpu_thread.h
@@ -59,6 +59,8 @@ class CpuThread
     json toJson();
 
    private:
+    bool m_speedInitialized = true;
+    bool m_powerInitialized = true;
 #if (defined(__i386__)) || (defined(__x86_64__))
     Rapl m_rapl;
 #endif

--- a/src/libraries/hanami_hardware/include/hanami_hardware/host.h
+++ b/src/libraries/hanami_hardware/include/hanami_hardware/host.h
@@ -53,7 +53,7 @@ class Host
     bool hasHyperThrading;
     std::vector<CpuPackage*> cpuPackages;
 
-    CpuPackage* getPackage(const uint32_t packageId) const;
+    CpuPackage* getPackage(const uint32_t pos) const;
     CpuPackage* addPackage(const uint32_t packageId);
 
     double getTotalTemperature(ErrorContainer& error);

--- a/src/libraries/hanami_hardware/src/cpu_thread.cpp
+++ b/src/libraries/hanami_hardware/src/cpu_thread.cpp
@@ -61,24 +61,28 @@ CpuThread::initThread(Host* host)
     if (getMinimumSpeed(minSpeed, threadId, error) == false) {
         LOG_WARNING(error.toString());
         error.reset();
+        m_speedInitialized = false;
     }
 
     // max-speed
     if (getMaximumSpeed(maxSpeed, threadId, error) == false) {
         LOG_WARNING(error.toString());
         error.reset();
+        m_speedInitialized = false;
     }
 
     // current-min-speed
     if (getCurrentMinimumSpeed(currentMinSpeed, threadId, error) == false) {
         LOG_WARNING(error.toString());
         error.reset();
+        m_speedInitialized = false;
     }
 
     // current-max-speed
     if (getCurrentMaximumSpeed(currentMaxSpeed, threadId, error) == false) {
         LOG_WARNING(error.toString());
         error.reset();
+        m_speedInitialized = false;
     }
 
     // core-id
@@ -100,7 +104,10 @@ CpuThread::initThread(Host* host)
     if (m_rapl.initRapl(error) == false) {
         LOG_WARNING(error.toString());
         error.reset();
+        m_powerInitialized = false;
     }
+#else
+    m_powerInitialized = false;
 #endif
 
     // add thread to the topological overview
@@ -119,6 +126,10 @@ CpuThread::initThread(Host* host)
 uint64_t
 CpuThread::getCurrentThreadSpeed() const
 {
+    if (m_speedInitialized == false) {
+        return 0;
+    }
+
     ErrorContainer error;
 
     uint64_t speed = 0;
@@ -138,6 +149,10 @@ CpuThread::getCurrentThreadSpeed() const
 double
 CpuThread::getThermalSpec() const
 {
+    if (m_powerInitialized == false) {
+        return 0.0;
+    }
+
 #if (defined(__i386__)) || (defined(__x86_64__))
     // check if RAPL was successfully initialized
     if (m_rapl.isActive() == false) {
@@ -158,6 +173,10 @@ CpuThread::getThermalSpec() const
 double
 CpuThread::getTotalPackagePower()
 {
+    if (m_powerInitialized == false) {
+        return 0.0;
+    }
+
 #if (defined(__i386__)) || (defined(__x86_64__))
     // check if RAPL was successfully initialized
     if (m_rapl.isActive() == false) {

--- a/src/libraries/hanami_hardware/src/host.cpp
+++ b/src/libraries/hanami_hardware/src/host.cpp
@@ -69,20 +69,14 @@ Host::initHost(ErrorContainer& error)
 /**
  * @brief get a package by id
  *
- * @param packageId id of the requested package
+ * @param pos position in list (this is not the package-id)
  *
  * @return nullptr, if there is no package with the id, else pointer to the package
  */
 CpuPackage*
-Host::getPackage(const uint32_t packageId) const
+Host::getPackage(const uint32_t pos) const
 {
-    for (CpuPackage* package : cpuPackages) {
-        if (package->packageId == packageId) {
-            return package;
-        }
-    }
-
-    return nullptr;
+    return cpuPackages.at(pos);
 }
 
 /**
@@ -96,12 +90,14 @@ Host::getPackage(const uint32_t packageId) const
 CpuPackage*
 Host::addPackage(const uint32_t packageId)
 {
-    CpuPackage* package = getPackage(packageId);
-
-    if (package == nullptr) {
-        package = new CpuPackage(packageId);
-        cpuPackages.push_back(package);
+    for (CpuPackage* package : cpuPackages) {
+        if (package->packageId == packageId) {
+            return package;
+        }
     }
+
+    CpuPackage* package = new CpuPackage(packageId);
+    cpuPackages.push_back(package);
 
     return package;
 }


### PR DESCRIPTION
## Pull Request

### Description

In virtual machines, it can happen, that the package-ids doesn't start with 0. This broke the measurement-loops, which tried to iterate over the packages starting with 0. This was fixed by not using the id anymore, but instead the position in the buffer for access, to ensure that it always starts at 0.

### Related Issues
- #280 

### How it was tested?

- tested on a vm, where it crached before the fix
