### PR TITLE
Add (#282): provide arm64 docker-images

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -1,5 +1,9 @@
 name: build-and-test
-on: [push]
+
+on: [push, create]
+
+env:
+  REGISTRY_IMAGE: kitsudaiki/hanami
 
 jobs:
   clang-format-check:
@@ -72,7 +76,7 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: kitsudaiki/hanami_builder:0.6.1
-    name: "build repository"
+    name: "Compile code"
     steps:
       - name: "Checkout repository"
         run: |
@@ -212,6 +216,113 @@ jobs:
     name: cleanup-job
     steps:
       - name: "Delete artifacts"
-        uses: geekyeggo/delete-artifact@v2
+        uses: geekyeggo/delete-artifact@v4
         with:
           name: result
+
+  docker_build:
+    name: "Build Docker-images"
+    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/develop' || github.event_name == 'create' && startsWith(github.ref, 'refs/tags/') }}
+    needs: [ unit_tests, memory_leak_tests, functional_tests ]
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - linux/amd64
+          - linux/arm64
+    steps:
+      - name: Prepare
+        run: |
+          platform=${{ matrix.platform }}
+          echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV          
+      - name: "Checkout repository"
+        run: |
+          # use manually clone, because with the "actions/checkout@v3" action the name of the
+          # branch can not be read by the git commands, which is necessary for the build-script
+          git clone https://github.com/kitsudaiki/${GITHUB_REPOSITORY#*/}.git
+          cd ${GITHUB_REPOSITORY#*/}
+          git checkout ${GITHUB_REF#refs/heads/}
+          git submodule init
+          git submodule update --recursive
+      - name: "Install packages"
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang-15 gcc g++ make cmake bison flex git ssh libssl-dev libcrypto++-dev libboost1.74-dev uuid-dev libsqlite3-dev protobuf-compiler nvidia-cuda-toolkit nano
+      - name: "Build project"
+        run:  |
+          cd ${GITHUB_REPOSITORY#*/}
+          ./build.sh
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY_IMAGE }}
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: check location
+        run: |
+          pwd
+          cd Hanami
+          ls -l
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v5
+        with:
+          context: ./Hanami
+          platforms: ${{ matrix.platform }}
+          labels: ${{ steps.meta.outputs.labels }}
+          outputs: type=image,name=${{ env.REGISTRY_IMAGE }},push-by-digest=true,name-canonical=true,push=true
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"          
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ env.PLATFORM_PAIR }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+  docker_merge:
+    name: "Merge and push Docker-image"
+    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/develop' || github.event_name == 'create' && startsWith(github.ref, 'refs/tags/') }}
+    runs-on: ubuntu-latest
+    # if: github.ref == 'refs/heads/develop'
+    needs:
+      - docker_build
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digests-*
+          merge-multiple: true
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY_IMAGE }}
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Create manifest list and push
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.REGISTRY_IMAGE }}@sha256:%s ' *)          
+      - name: Inspect image
+        run: |
+          docker buildx imagetools inspect ${{ env.REGISTRY_IMAGE }}:${{ steps.meta.outputs.version }}       

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+FROM ubuntu:22.04
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && \
+    apt-get install -y openssl libuuid1 libcrypto++8 libsqlite3-0 libprotobuf23 libboost1.74 libcudart11.0 && \
+    apt-get clean autoclean &&\
+    apt-get autoremove --yes
+
+COPY src/frontend/Hanami-Dashboard /etc/Hanami-Dashboard
+
+# Remove symlinks in order to replace them by the real repos
+RUN rm /etc/Hanami-Dashboard/src/sdk /etc/Hanami-Dashboard/src/hanami_messages /etc/Hanami-Dashboard/src/Hanami-Dashboard-Dependencies
+
+# Dashboard
+COPY src/sdk /etc/Hanami-Dashboard/src/sdk
+COPY src/libraries/hanami_messages /etc/Hanami-Dashboard/src/hanami_messages
+COPY src/frontend/Hanami-Dashboard-Dependencies /etc/Hanami-Dashboard/src/Hanami-Dashboard-Dependencies
+
+# Hanami
+COPY src/Hanami/Hanami /usr/bin/Hanami
+CMD Hanami

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ![Github workfloat status](https://img.shields.io/github/actions/workflow/status/kitsudaiki/Hanami/build_test.yml?branch=develop&style=flat-square&label=build%20and%20test)
 ![GitHub tag (latest SemVer)](https://img.shields.io/github/v/tag/kitsudaiki/Hanami?label=version&style=flat-square)
 ![GitHub](https://img.shields.io/github/license/kitsudaiki/Hanami-AI?style=flat-square)
-![Platform](https://img.shields.io/badge/platform-Linux--x64-lightgrey?style=flat-square)
+![Platform](https://img.shields.io/badge/Platform-Linux--x64|arm64-lightgrey?style=flat-square)
 
 <p align="center">
   <img src="assets/hanami-logo-with-text.png" width="500" height="594" />


### PR DESCRIPTION

## Pull Request

### Description

Updated ci-pipeline to automatically build and
push amd64 and arm64 linux docker-images for
develop-branch and tags.

### Related Issues

- #282

<!-- In context of which issues the changes of this pull request were created. -->

### How it was tested?

- only updated ci-pipeline
