### PR TITLE
Add (#284): add automatic docs-build to ci

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -1,9 +1,10 @@
 name: build-and-test
 
-on: [push, create]
+on: [push]
 
 env:
   REGISTRY_IMAGE: kitsudaiki/hanami
+  REGISTRY_DOCS_IMAGE: kitsudaiki/hanami_docs
 
 jobs:
   clang-format-check:
@@ -203,8 +204,57 @@ jobs:
       #     chmod +x /tmp/build_result/libraries/hanami_network/tests/functional_tests/functional_tests
       #     /tmp/build_result/libraries/hanami_network/tests/functional_tests/functional_tests
 
-  cleanup:
+  build_docs:
     needs: [ unit_tests, memory_leak_tests, functional_tests ]
+    runs-on: ubuntu-latest
+    name: Build and push docs
+    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/develop' || github.event_name == 'create' && startsWith(github.ref, 'refs/tags/') }}
+    env:
+      FORCE_COLOR: 1
+    steps:
+      - name: Set branch name as environment variable
+        run: echo "BRANCH_NAME=$(echo ${GITHUB_REF#refs/heads/})" | sed 's#/#\-#' >> $GITHUB_ENV
+      - uses: earthly/actions-setup@v1
+        with:
+          version: v0.8.0
+      - name: Get artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: result
+          path: /tmp/build_result
+      - name: Checkout repository
+        run: |
+          # use manually clone, because with the "actions/checkout@v3" action the name of the
+          # branch can not be read by the git commands, which is necessary for the build-script
+          git clone https://github.com/kitsudaiki/${GITHUB_REPOSITORY#*/}.git
+          cd ${GITHUB_REPOSITORY#*/}
+          git checkout ${GITHUB_REF#refs/heads/}
+          git submodule init
+          git submodule update --recursive
+      - name: Prepare Binary
+        run: |
+          cd ${GITHUB_REPOSITORY#*/}
+          chmod +x /tmp/build_result/Hanami
+          mkdir -p builds/binaries
+          cp /tmp/build_result/Hanami ./builds/binaries/
+      - name: Generate code-docs
+        run: |
+          cd ${GITHUB_REPOSITORY#*/}
+          earthly --artifact +generate-code-docu/tmp/Hanami_docs ./builds/docs
+      - name: Build docs
+        run: |
+          cd ${GITHUB_REPOSITORY#*/}
+          earthly  +build-docs --image_name=${{ env.REGISTRY_DOCS_IMAGE }}:${{ env.BRANCH_NAME }}
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Push image
+        run: docker push ${{ env.REGISTRY_DOCS_IMAGE }}:${{ env.BRANCH_NAME }}
+
+  cleanup:
+    needs: [ build_docs ]
     runs-on: ubuntu-latest
     name: cleanup-job
     steps:
@@ -261,7 +311,7 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: check location
+      - name: Check location
         run: |
           pwd
           cd Hanami
@@ -286,6 +336,7 @@ jobs:
           path: /tmp/digests/*
           if-no-files-found: error
           retention-days: 1
+
   docker_merge:
     name: "Merge and push Docker-image"
     if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/develop' || github.event_name == 'create' && startsWith(github.ref, 'refs/tags/') }}

--- a/Earthfile
+++ b/Earthfile
@@ -66,12 +66,6 @@ ansible-lint:
     RUN ansible-lint deploy/ansible/hanami
 
 
-
-
-
-
-
-
 prepare-build-dependencies:
     RUN apt-get update && \
         apt-get install -y clang-15 \


### PR DESCRIPTION


## Pull Request

### Description

The ci-pipeline now builds the docs as
docker-image and push it to docker-hub
for each commit on develop-branch and for
each tag.
<!-- A concise description of the content of the pull-request -->

### Related Issues

- #284
<!-- In context of which issues the changes of this pull request were created. -->

### How it was tested?

- update ci-pipeline
<!-- What parts and how they were tested -->
