### PR TITLE
Fix (#285): fix final docker-build

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -279,7 +279,10 @@ jobs:
         run: |
           platform=${{ matrix.platform }}
           echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV          
-      - name: "Checkout repository"
+      - uses: earthly/actions-setup@v1
+        with:
+          version: v0.8.0
+      - name: Checkout repository
         run: |
           # use manually clone, because with the "actions/checkout@v3" action the name of the
           # branch can not be read by the git commands, which is necessary for the build-script
@@ -288,15 +291,10 @@ jobs:
           git checkout ${GITHUB_REF#refs/heads/}
           git submodule init
           git submodule update --recursive
-      - name: "Install packages"
+      - name: Compile code
         run: |
-          sudo apt-get update
-          sudo apt-get install -y clang-15 gcc g++ make cmake bison flex git ssh libssl-dev libcrypto++-dev libboost1.74-dev uuid-dev libsqlite3-dev protobuf-compiler nvidia-cuda-toolkit nano
-      - name: "Build project"
-        run:  |
           cd ${GITHUB_REPOSITORY#*/}
-          cmake -DCMAKE_BUILD_TYPE=Release .
-          make -j8
+          earthly --artifact +compile-code/tmp/Hanami ./builds/binaries
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v5
@@ -341,7 +339,6 @@ jobs:
     name: "Merge and push Docker-image"
     if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/develop' || github.event_name == 'create' && startsWith(github.ref, 'refs/tags/') }}
     runs-on: ubuntu-22.04
-    # if: github.ref == 'refs/heads/develop'
     needs:
       - docker_build
     steps:

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,5 +18,5 @@ COPY src/libraries/hanami_messages /etc/Hanami-Dashboard/src/hanami_messages
 COPY src/frontend/Hanami-Dashboard-Dependencies /etc/Hanami-Dashboard/src/Hanami-Dashboard-Dependencies
 
 # Hanami
-COPY src/Hanami/Hanami /usr/bin/Hanami
+COPY ./builds/binaries/Hanami /usr/bin/Hanami
 CMD Hanami


### PR DESCRIPTION

## Pull Request

### Description
The final docker-build step still had
not used the new Earthfile and had build
their code outside of the docker-containers
which broke the code, because of the
switch of the environment. This was now
fixed by using the Earthfile to build
the code within a container too.

<!-- A concise description of the content of the pull-request -->

### Related Issues

- #285
<!-- In context of which issues the changes of this pull request were created. -->

### How it was tested?

- build images via ci and checked that Hanami is starting within these container
