### PR TITLE
Change (#292): replace static salt-value

### DIFF
--- a/src/Hanami/src/database/users_table.cpp
+++ b/src/Hanami/src/database/users_table.cpp
@@ -160,8 +160,8 @@ UsersTable::initNewAdminUser(Hanami::ErrorContainer& error)
 
     // generate hash from password
     std::string pwHash;
-    // TODO: replace by random salt
-    const std::string salt = "e307bee0-9286-49bd-9273-6f644c12da1d";
+    std::string salt = "";
+    Hanami::generate_SHA_256(salt, generateUuid().toString());
     const std::string saltedPw = pw + salt;
     Hanami::generate_SHA_256(pwHash, saltedPw);
 


### PR DESCRIPTION

## Pull Request

### Description
The salt-value for password hashed was a project-specific static string. It was replaced by a random string, so each user now has an different salt-value.

<!-- A concise description of the content of the pull-request -->

### Related Issues
-  #292
<!-- In context of which issues the changes of this pull request were created. -->

### How it was tested?

- only ci-pipeline
<!-- What parts and how they were tested -->
