### PR TITLE
Fix (#328): fix ansible deploy in CI

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -622,9 +622,8 @@ jobs:
       -
         name: Install Ansible
         run: |
-          sudo apt-add-repository -y ppa:ansible/ansible
-          sudo apt update
-          sudo apt install ansible
+          sudo pip3 install -U ansible requests==2.31.0
+          sudo pip3 list
       - 
         name: Install Hanami via Ansible
         run: |


### PR DESCRIPTION


## Pull Request

### Description

The CI was broken in the test for deploying
Hanami with Ansible. The source of the problem
was a conflict in 2 python-dependencies. It was
fixed by pinning the requests-package to version
2.31.0

### Related Issues

- #328 
<!-- In context of which issues the changes of this pull request were created. -->

### How it was tested?

- CI-pipeline
<!-- What parts and how they were tested -->
