### PR TITLE
Add (#316): add configuration for memory-consumption

### DIFF
--- a/deploy/ansible/hanami/roles/hanami/defaults/main.yml
+++ b/deploy/ansible/hanami/roles/hanami/defaults/main.yml
@@ -9,6 +9,8 @@ hanami_dataset_location: "/etc/hanami/datasets"
 hanami_checkpoint_location: "/etc/hanami/checkpoints"
 hanami_tempfile_location: "/etc/hanami/tempfiles"
 
+hanami_use_of_free_memory: 0.5
+
 hanami_token_key_path: "/etc/hanami/token_key"
 hanami_ssl_cert_path: "/etc/hanami/cert.pem"
 hanami_ssl_key_path: "/etc/hanami/key.pem"

--- a/deploy/ansible/hanami/roles/hanami/templates/hanami.conf.j2
+++ b/deploy/ansible/hanami/roles/hanami/templates/hanami.conf.j2
@@ -10,6 +10,9 @@ checkpoint_location = {{hanami_checkpoint_location}}
 tempfile_location = {{hanami_tempfile_location}}
 tempfile_timeout = 10
 
+[processing]
+use_of_free_memory = {{hanami_use_of_free_memory}}
+
 [auth] 
 policies = "/etc/hanami/policies" 
 token_key_path = {{hanami_token_key_path}} 

--- a/deploy/k8s/hanami/templates/hanami-config.yaml
+++ b/deploy/k8s/hanami/templates/hanami-config.yaml
@@ -15,6 +15,9 @@ data:
     tempfile_location = "/etc/hanami/data/tempfiles"
     tempfile_timeout = 10
 
+    [processing]
+    use_of_free_memory = {{ .Values.use_of_free_memory }}
+
     [auth]
     policies = "/etc/hanami/policies"
     token_key_path = "/etc/hanami/token_key"

--- a/deploy/k8s/hanami/values.yaml
+++ b/deploy/k8s/hanami/values.yaml
@@ -22,6 +22,9 @@ api:
   port: 11418
   ip: "0.0.0.0"
 
+processing:
+  use_of_free_memory: 0.5
+
 resources: {}
 
 nodeSelector: {}

--- a/example_configs/hanami/hanami.conf
+++ b/example_configs/hanami/hanami.conf
@@ -10,6 +10,9 @@ checkpoint_location = "/etc/hanami/checkpoints"
 tempfile_location = "/etc/hanami/tempfiles"
 tempfile_timeout = 10
 
+[processing]
+use_of_free_memory = 0.5
+
 [auth]
 policies = "/etc/hanami/policies"
 token_key_path = "/etc/hanami/token_key"

--- a/src/Hanami/src/config.h
+++ b/src/Hanami/src/config.h
@@ -67,6 +67,15 @@ registerConfigs()
         .setComment("Number of minutes, until an inactive timefile is removed.")
         .setDefault(10);
 
+    // processing-section
+    const std::string processingGroup = "processing";
+    REGISTER_FLOAT_CONFIG(processingGroup, "use_of_free_memory")
+        .setComment(
+            "Define the percentage allcating free memory on the host (example: 0.5 = 50%). "
+            "Maximum is 90% and will be hard cut, in case a value higher than 0.9 is provided. "
+            "The minimum is 0.1")
+        .setDefault(0.5);
+
     // auth-section
     const std::string authGroup = "auth";
 

--- a/src/Hanami/src/core/processing/cpu/cpu_host.cpp
+++ b/src/Hanami/src/core/processing/cpu/cpu_host.cpp
@@ -28,6 +28,7 @@
 #include <core/processing/cpu/processing.h>
 #include <core/processing/cpu/reduction.h>
 #include <core/processing/cpu/worker_thread.h>
+#include <hanami_config/config_handler.h>
 #include <hanami_cpu/memory.h>
 #include <hanami_hardware/cpu_core.h>
 #include <hanami_hardware/cpu_package.h>
@@ -92,7 +93,16 @@ void
 CpuHost::initBuffer(const uint32_t id)
 {
     m_totalMemory = getFreeMemory();
-    const uint64_t usedMemory = (m_totalMemory / 100) * 10;  // use 10% for synapse-blocks
+    bool success = false;
+    float memoryUsage = GET_FLOAT_CONFIG("processing", "use_of_free_memory", success);
+    // TODO: handle amound of min and max value by ranges inside of the config-lib
+    if (memoryUsage < 0.1f) {
+        memoryUsage = 0.1f;
+    }
+    if (memoryUsage > 0.9f) {
+        memoryUsage = 0.9f;
+    }
+    const uint64_t usedMemory = static_cast<float>(m_totalMemory) * memoryUsage;
     synapseBlocks.initBuffer<SynapseBlock>(usedMemory / sizeof(SynapseBlock));
     synapseBlocks.deleteAll();
 


### PR DESCRIPTION
## Pull Request

### Description

Added config-entry to define the percentage of max amount of used free memory. Also added the option
to the example-config, helm-chart and ansible-playbook. Default is 0.5 or 50%.

<!-- A concise description of the content of the pull-request -->

### Related Issues

- #316
<!-- In context of which issues the changes of this pull request were created. -->

### How it was tested?

- manually testing with different configs while checking the memory-consumption in htop
<!-- What parts and how they were tested -->
