### PR TITLE
Change (#370): reduce complexity of core

### DIFF
--- a/src/Hanami/src/core/cluster/objects.h
+++ b/src/Hanami/src/core/cluster/objects.h
@@ -46,9 +46,9 @@ class Cluster;
 #define UNINTI_POINT_32 0x0FFFFFFF
 
 // network-predefines
-#define SYNAPSES_PER_SYNAPSESECTION 64
-#define NUMBER_OF_SYNAPSESECTION 64
-#define NEURONS_PER_NEURONBLOCK 64
+#define SYNAPSES_PER_SYNAPSESECTION 128
+#define NUMBER_OF_SYNAPSESECTION 512
+#define NEURONS_PER_NEURONBLOCK 128
 #define POSSIBLE_NEXT_AXON_STEP 80
 #define NUMBER_OF_POSSIBLE_NEXT 86
 #define NUMBER_OF_OUTPUT_CONNECTIONS 7
@@ -165,7 +165,7 @@ struct SynapseSection {
 
     SynapseSection() { std::fill_n(synapses, SYNAPSES_PER_SYNAPSESECTION, Synapse()); }
 };
-static_assert(sizeof(SynapseSection) == 1024);
+static_assert(sizeof(SynapseSection) == 2048);
 
 //==================================================================================================
 
@@ -174,7 +174,7 @@ struct SynapseBlock {
 
     SynapseBlock() { std::fill_n(sections, NUMBER_OF_SYNAPSESECTION, SynapseSection()); }
 };
-static_assert(sizeof(SynapseBlock) == 64 * 1024);
+static_assert(sizeof(SynapseBlock) == 512 * 2048);
 
 //==================================================================================================
 
@@ -224,7 +224,7 @@ struct NeuronBlock {
 
     NeuronBlock() { std::fill_n(neurons, NEURONS_PER_NEURONBLOCK, Neuron()); }
 };
-static_assert(sizeof(NeuronBlock) == 2048);
+static_assert(sizeof(NeuronBlock) == 4096);
 
 //==================================================================================================
 
@@ -289,7 +289,7 @@ struct ConnectionBlock {
 
     ConnectionBlock() { std::fill_n(connections, NUMBER_OF_SYNAPSESECTION, SynapseConnection()); }
 };
-static_assert(sizeof(ConnectionBlock) == 1544);
+static_assert(sizeof(ConnectionBlock) == 12296);
 
 //==================================================================================================
 
@@ -315,9 +315,9 @@ struct HexagonHeader {
     uint32_t hexagonId = UNINIT_STATE_32;
     bool isInputHexagon = false;
     bool isOutputHexagon = false;
-    uint8_t padding1[2];
+    uint8_t padding[2];
+    uint32_t numberOfFreeSections = 0;
     uint32_t dimX = 0;
-    uint32_t dimY = 0;
     Hanami::Position hexagonPos;
 
     bool operator==(HexagonHeader& rhs)
@@ -332,9 +332,6 @@ struct HexagonHeader {
             return false;
         }
         if (dimX != rhs.dimX) {
-            return false;
-        }
-        if (dimY != rhs.dimY) {
             return false;
         }
         if (hexagonPos != rhs.hexagonPos) {

--- a/src/Hanami/src/core/io/checkpoint/io_interface.cpp
+++ b/src/Hanami/src/core/io/checkpoint/io_interface.cpp
@@ -531,7 +531,7 @@ IO_Interface::checkHexagonEntry(const HexagonEntry& hexagonEntry)
     // check size against dimentsions in hexagon-header
     const uint64_t numberOfConnectionBlocks
         = hexagonEntry.numberOfConnectionBytes / (sizeof(ConnectionBlock) + sizeof(SynapseBlock));
-    if (numberOfConnectionBlocks != hexagonEntry.header.dimX * hexagonEntry.header.dimY) {
+    if (numberOfConnectionBlocks != hexagonEntry.header.dimX) {
         return false;
     }
 

--- a/src/Hanami/src/core/io/checkpoint/io_interface.h
+++ b/src/Hanami/src/core/io/checkpoint/io_interface.h
@@ -34,7 +34,7 @@ namespace Hanami
 struct DataBuffer;
 }
 
-#define LOCAL_BUFFER_SIZE 128 * 1024
+#define LOCAL_BUFFER_SIZE 1024 * 4096
 
 class IO_Interface
 {
@@ -95,6 +95,7 @@ class IO_Interface
     template <typename T>
     inline bool addObjectToLocalBuffer(T* data, Hanami::ErrorContainer& error)
     {
+        assert(sizeof(T) < LOCAL_BUFFER_SIZE);
         if (sizeof(T) + m_localBuffer.size > LOCAL_BUFFER_SIZE) {
             if (writeFromLocalBuffer(m_localBuffer, error) == false) {
                 error.addMessage("Failed to write local buffer to target");

--- a/src/Hanami/src/core/processing/cpu/backpropagation.h
+++ b/src/Hanami/src/core/processing/cpu/backpropagation.h
@@ -128,34 +128,29 @@ backpropagateConnections(Hexagon* hexagon,
     NeuronBlock* targetNeuronBlock = nullptr;
     ConnectionBlock* connectionBlock = nullptr;
     SynapseSection* synapseSection = nullptr;
-    const uint32_t dimY = hexagon->header.dimY;
     const uint32_t dimX = hexagon->header.dimX;
     SourceLocation sourceLoc;
-    uint32_t c = 0;
-    uint32_t i = 0;
 
     if (blockId >= dimX) {
         return;
     }
 
-    for (c = blockId * dimY; c < (blockId * dimY) + dimY; ++c) {
-        assert(c < hexagon->connectionBlocks.size());
-        connectionBlock = &hexagon->connectionBlocks[c];
+    assert(blockId < hexagon->connectionBlocks.size());
+    connectionBlock = &hexagon->connectionBlocks[blockId];
 
-        for (i = 0; i < NUMBER_OF_SYNAPSESECTION; ++i) {
-            connection = &connectionBlock->connections[i];
+    for (uint32_t i = 0; i < NUMBER_OF_SYNAPSESECTION; ++i) {
+        connection = &connectionBlock->connections[i];
 
-            if (connection->origin.blockId == UNINIT_STATE_16) {
-                continue;
-            }
-
-            synapseSection = &synapseBlocks[connectionBlock->targetSynapseBlockPos].sections[i];
-            sourceLoc = getSourceNeuron(connection->origin, hexagons);
-
-            targetNeuronBlock = &hexagon->neuronBlocks[(c / hexagon->header.dimY)];
-
-            backpropagateSection(synapseSection, connection, targetNeuronBlock, sourceLoc.neuron);
+        if (connection->origin.blockId == UNINIT_STATE_16) {
+            continue;
         }
+
+        synapseSection = &synapseBlocks[connectionBlock->targetSynapseBlockPos].sections[i];
+        sourceLoc = getSourceNeuron(connection->origin, hexagons);
+
+        targetNeuronBlock = &hexagon->neuronBlocks[blockId];
+
+        backpropagateSection(synapseSection, connection, targetNeuronBlock, sourceLoc.neuron);
     }
 }
 

--- a/src/Hanami/src/core/processing/cpu/processing.h
+++ b/src/Hanami/src/core/processing/cpu/processing.h
@@ -183,11 +183,8 @@ processSynapses(Cluster& cluster, Hexagon* hexagon, const uint32_t blockId)
     SynapseSection* section = nullptr;
     Hexagon* sourceHexagon = nullptr;
     uint32_t randomeSeed = rand();
-    const uint32_t dimY = hexagon->header.dimY;
     const uint32_t dimX = hexagon->header.dimX;
     SourceLocation sourceLoc;
-    uint32_t c = 0;
-    uint32_t i = 0;
 
     bool inputConnected = false;
 
@@ -195,37 +192,35 @@ processSynapses(Cluster& cluster, Hexagon* hexagon, const uint32_t blockId)
         return;
     }
 
-    for (c = blockId * dimY; c < (blockId * dimY) + dimY; ++c) {
-        assert(c < hexagon->connectionBlocks.size());
-        connectionBlock = &hexagon->connectionBlocks[c];
+    assert(blockId < hexagon->connectionBlocks.size());
+    connectionBlock = &hexagon->connectionBlocks[blockId];
 
-        for (i = 0; i < NUMBER_OF_SYNAPSESECTION; ++i) {
-            scon = &connectionBlock->connections[i];
-            if (scon->origin.blockId == UNINIT_STATE_16) {
-                continue;
-            }
-
-            inputConnected = scon->origin.isInput;
-            sourceLoc = getSourceNeuron(scon->origin, &cluster.hexagons[0]);
-
-            if (sourceLoc.neuron->active == 0) {
-                continue;
-            }
-
-            section = &synapseBlocks[connectionBlock->targetSynapseBlockPos].sections[i];
-            targetNeuronBlock = &neuronBlocks[(c / hexagon->header.dimY)];
-            randomeSeed += (c * NUMBER_OF_SYNAPSESECTION) + i;
-
-            synapseProcessingBackward<doTrain>(cluster,
-                                               section,
-                                               scon,
-                                               targetNeuronBlock,
-                                               sourceLoc.neuron,
-                                               scon->origin,
-                                               clusterSettings,
-                                               inputConnected,
-                                               randomeSeed);
+    for (uint32_t i = 0; i < NUMBER_OF_SYNAPSESECTION; ++i) {
+        scon = &connectionBlock->connections[i];
+        if (scon->origin.blockId == UNINIT_STATE_16) {
+            continue;
         }
+
+        inputConnected = scon->origin.isInput;
+        sourceLoc = getSourceNeuron(scon->origin, &cluster.hexagons[0]);
+
+        if (sourceLoc.neuron->active == 0) {
+            continue;
+        }
+
+        section = &synapseBlocks[connectionBlock->targetSynapseBlockPos].sections[i];
+        targetNeuronBlock = &neuronBlocks[blockId];
+        randomeSeed += (blockId * NUMBER_OF_SYNAPSESECTION) + i;
+
+        synapseProcessingBackward<doTrain>(cluster,
+                                           section,
+                                           scon,
+                                           targetNeuronBlock,
+                                           sourceLoc.neuron,
+                                           scon->origin,
+                                           clusterSettings,
+                                           inputConnected,
+                                           randomeSeed);
     }
 }
 

--- a/src/Hanami/src/core/processing/cpu/reduction.h
+++ b/src/Hanami/src/core/processing/cpu/reduction.h
@@ -86,39 +86,34 @@ reduceConnections(Hexagon* hexagon,
     Hexagon* sourceHexagon = nullptr;
     ConnectionBlock* connectionBlock = nullptr;
     SynapseSection* synapseSection = nullptr;
-    const uint32_t dimY = hexagon->header.dimY;
     const uint32_t dimX = hexagon->header.dimX;
-    uint32_t c = 0;
-    uint32_t i = 0;
 
     if (blockId >= dimX) {
         return;
     }
 
-    for (c = blockId * dimY; c < (blockId * dimY) + dimY; ++c) {
-        connectionBlock = &hexagon->connectionBlocks[c];
+    connectionBlock = &hexagon->connectionBlocks[blockId];
 
-        for (i = 0; i < NUMBER_OF_SYNAPSESECTION; ++i) {
-            connection = &connectionBlock->connections[i];
-            if (connection->origin.blockId == UNINIT_STATE_16) {
-                continue;
-            }
+    for (uint32_t i = 0; i < NUMBER_OF_SYNAPSESECTION; ++i) {
+        connection = &connectionBlock->connections[i];
+        if (connection->origin.blockId == UNINIT_STATE_16) {
+            continue;
+        }
 
-            synapseSection = &synapseBlocks[connectionBlock->targetSynapseBlockPos].sections[i];
-            sourceHexagon = &hexagons[connection->origin.hexagonId];
-            sourceNeuronBlock = &sourceHexagon->neuronBlocks[connection->origin.blockId];
-            sourceNeuron = &sourceNeuronBlock->neurons[connection->origin.neuronId];
+        synapseSection = &synapseBlocks[connectionBlock->targetSynapseBlockPos].sections[i];
+        sourceHexagon = &hexagons[connection->origin.hexagonId];
+        sourceNeuronBlock = &sourceHexagon->neuronBlocks[connection->origin.blockId];
+        sourceNeuron = &sourceNeuronBlock->neurons[connection->origin.neuronId];
 
-            // if section is complete empty, then erase it
-            if (reduceSection(synapseSection) == false) {
-                // initialize the creation of a new section
-                sourceNeuron->isNew = 1;
-                sourceNeuron->newLowerBound = connection->lowerBound;
+        // if section is complete empty, then erase it
+        if (reduceSection(synapseSection) == false) {
+            // initialize the creation of a new section
+            sourceNeuron->isNew = 1;
+            sourceNeuron->newLowerBound = connection->lowerBound;
 
-                // mark current connection as available again
-                connection->origin.blockId = UNINIT_STATE_16;
-                connection->origin.neuronId = UNINIT_STATE_8;
-            }
+            // mark current connection as available again
+            connection->origin.blockId = UNINIT_STATE_16;
+            connection->origin.neuronId = UNINIT_STATE_8;
         }
     }
 }

--- a/src/Hanami/src/core/processing/cuda/backpropagation.cu
+++ b/src/Hanami/src/core/processing/cuda/backpropagation.cu
@@ -173,11 +173,11 @@ backpropagation_CUDA(CudaClusterPointer* gpuPointer,
         backpropagateNeurons<<<hexagon->header.dimX, 64>>>(
                 gpuPointer->hexagonPointer[hexagonId].neuronBlocks);
 
-        backpropagateConnections<<<hexagon->header.dimX * hexagon->header.dimY, 64>>>(
+        backpropagateConnections<<<hexagon->header.dimX, 64>>>(
                 gpuPointer->hexagonPointer[hexagonId].neuronBlocks,
                 gpuPointer->synapseBlocks,
                 gpuPointer->hexagonPointer[hexagonId].connectionBlocks,
-                hexagon->header.dimY);
+                42);
 
         // copy neurons back to host
         cudaMemcpy(&hexagon->neuronBlocks[0],

--- a/src/Hanami/src/core/processing/cuda/processing.cu
+++ b/src/Hanami/src/core/processing/cuda/processing.cu
@@ -343,38 +343,38 @@ processing_CUDA(CudaClusterPointer* gpuPointer,
 
         if (doTrain)
         {
-            processSynapses<true><<<hexagon->header.dimX * hexagon->header.dimY, 64>>>(
+            processSynapses<true><<<hexagon->header.dimX, 64>>>(
                 gpuPointer->hexagonPointer[hexagonId].neuronBlocks,
                 gpuPointer->synapseBlocks,
                 gpuPointer->hexagonPointer[hexagonId].connectionBlocks,
                 gpuPointer->clusterSettings,
                 randomeSeed + hexagonId,
-                hexagon->header.dimY);
+                42);
 
             processNeurons<true><<<hexagon->header.dimX, 64>>>(
                 gpuPointer->hexagonPointer[hexagonId].neuronBlocks,
                 gpuPointer->synapseBlocks,
                 gpuPointer->hexagonPointer[hexagonId].connectionBlocks,
                 gpuPointer->clusterSettings,
-                hexagon->header.dimY,
+                42,
                 hexagon->header.isOutputHexagon);
         }
         else
         {
-            processSynapses<false><<<hexagon->header.dimX * hexagon->header.dimY, 64>>>(
+            processSynapses<false><<<hexagon->header.dimX, 64>>>(
                 gpuPointer->hexagonPointer[hexagonId].neuronBlocks,
                 gpuPointer->synapseBlocks,
                 gpuPointer->hexagonPointer[hexagonId].connectionBlocks,
                 gpuPointer->clusterSettings,
                 randomeSeed + hexagonId,
-                hexagon->header.dimY);
+                42);
 
             processNeurons<false><<<hexagon->header.dimX, 64>>>(
                 gpuPointer->hexagonPointer[hexagonId].neuronBlocks,
                 gpuPointer->synapseBlocks,
                 gpuPointer->hexagonPointer[hexagonId].connectionBlocks,
                 gpuPointer->clusterSettings,
-                hexagon->header.dimY,
+                42,
                 hexagon->header.isOutputHexagon);
         }
 


### PR DESCRIPTION
## Pull Request

### Description

Update core-structure form a square of synapse-blocks into a linear order ob blocks. This reduce the
flexibility a bit, but also the complexity, which
solves the problem of the exact definition of
required memory and makes gpu-support much easier.

<!-- A concise description of the content of the pull-request -->

### Related Issues

- #370
<!-- In context of which issues the changes of this pull request were created. -->

### How it was tested?

- sdk-api-test
<!-- What parts and how they were tested -->
