### PR TITLE
fix(#395): fix arm64-build

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -902,11 +902,6 @@ jobs:
           git submodule init
           git submodule update --recursive
       - 
-        name: Compile code
-        run: |
-          cd ${GITHUB_REPOSITORY#*/}
-          earthly --artifact +compile-code/tmp/hanami ./builds/binaries
-      - 
         name: Docker meta
         id: meta
         uses: docker/metadata-action@8e5442c4ef9f78752691e2d8f8d19755c6f78e81

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -129,7 +129,7 @@
         "filename": ".github/workflows/build_test.yml",
         "hashed_secret": "92429d82a41e930486c6de5ebda9602d55c39986",
         "is_verified": false,
-        "line_number": 1225
+        "line_number": 1220
       }
     ],
     "deploy/k8s/hanami/templates/hanami-certificate.yaml": [
@@ -850,5 +850,5 @@
       }
     ]
   },
-  "generated_at": "2024-07-29T21:10:35Z"
+  "generated_at": "2024-07-30T13:31:44Z"
 }


### PR DESCRIPTION
Arm64 docker-images were broken

## Pull Request

### Description

- fix arm64-build
<!-- A concise description of the content of the pull-request -->

### Related Issues

- #395 
<!-- In context of which issues the changes of this pull request were created. -->

### How it was tested?

- manually tested by enforcing the complete build, rolled out the arm64-docker-image on an ARM64 hetzner-VM, executed the container and successfully started the hanami binary.
<!-- What parts and how they were tested -->
