### PR TITLE
ci(#321): added basic commitlinter conf

### DIFF
--- a/commitlint.config.mjs
+++ b/commitlint.config.mjs
@@ -1,0 +1,3 @@
+export default {
+  ignores: [(commit) => commit.startsWith('chore(deps)')]
+};


### PR DESCRIPTION

## Pull Request

### Description
Added basic commitlinter config to ignore
commits, which comming from the Dependabot,
which are not always valid for the linter.

<!-- A concise description of the content of the pull-request -->

### Related Issues

- #321
<!-- In context of which issues the changes of this pull request were created. -->

### How it was tested?

- not tested yet
<!-- What parts and how they were tested -->
