### PR TITLE
fix: update protobuf pip-package

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,9 +18,9 @@ updates:
       - "kitsudaiki"
     ignore:
       - dependency-name: 'protobuf'
-        # Must be pinned to a maximum of version 3.20.1
+        # Must be pinned to a maximum of version 3.20.3
         # see https://github.com/protocolbuffers/protobuf/issues/10051
-        versions: '> 3.20.1'
+        versions: '> 3.20.3'
 
   - package-ecosystem: gomod 
     directory: "/src/cli/hanamictl/"

--- a/src/sdk/python/hanami_sdk/requirements.txt
+++ b/src/sdk/python/hanami_sdk/requirements.txt
@@ -1,5 +1,5 @@
 jsonschema==4.23.0
-protobuf==3.20.1
+protobuf==3.20.3
 requests==2.32.3
 simplejson==3.19.2
 websockets==12.0

--- a/src/sdk/python/hanami_sdk/setup.py
+++ b/src/sdk/python/hanami_sdk/setup.py
@@ -29,7 +29,7 @@ setup(
     license='Apache 2.0',
     packages=['hanami_sdk', 'hanami_sdk.hanami_messages'],
     install_requires=['jsonschema==4.23.0',
-                      'protobuf==3.20.1',
+                      'protobuf==3.20.3',
                       'requests==2.32.3',
                       'simplejson==3.19.2',
                       'websockets==12.0'],


### PR DESCRIPTION


## Pull Request

### Description

Updated protobuf pip-package from 3.20.1
to 3.20.3 because of security warnings.
<!-- A concise description of the content of the pull-request -->

### Related Issues

- no issue
<!-- In context of which issues the changes of this pull request were created. -->

### How it was tested?

- ci-pipeline
<!-- What parts and how they were tested -->
