### PR TITLE
feat(#439): update task input styling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ src/sdk/python/sdk_test_env
 src/sdk/python/hanami_sdk/dist
 src/sdk/python/hanami_sdk/build
 src/sdk/python/hanami_sdk/hanami_sdk.egg-info
+src/sdk/python/hanami_sdk/hanami_messages
 
 gitIdentityChange.sh
 proto3_pb2.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### BREAKING-CHANGES
 
+#### API-Breaking
+
+- the input definition for the tasks was changes to removed the naming restriction between dataset-column and hexagon-name
+
 #### Template-Breaking
 
 - removed `target`-keyword from cluster-templates

--- a/docs/frontend/cli_sdk_docu.md
+++ b/docs/frontend/cli_sdk_docu.md
@@ -645,7 +645,7 @@ label-file of the same dataset.
     | VERSION           | v1.0alpha                                                                                     |
     | NUMBER OF COLUMNS | 794                                                                                           |
     | NUMBER OF ROWS    | 60000                                                                                         |
-    | DESCRIPTION       | {"label":{"end_column":794,"start_column":784},"picture":{"end_column":784,"start_column":0}} |
+    | DESCRIPTION       | {"label":{"column_end":794,"column_start":784},"picture":{"column_end":784,"column_start":0}} |
     | VISIBILITY        | private                                                                                       |
     | OWNER ID          | asdf                                                                                          |
     | PROJECT ID        | admin                                                                                         |
@@ -696,7 +696,7 @@ label-file of the same dataset.
     | VERSION           | v1.0alpha                                                                                        |
     | NUMBER OF COLUMNS | 2                                                                                                |
     | NUMBER OF ROWS    | 1723                                                                                             |
-    | DESCRIPTION       | {"test_input":{"end_column":1,"start_column":0},"test_output":{"end_column":2,"start_column":1}} |
+    | DESCRIPTION       | {"test_input":{"column_end":1,"column_start":0},"test_output":{"column_end":2,"column_start":1}} |
     | VISIBILITY        | private                                                                                          |
     | OWNER ID          | asdf                                                                                             |
     | PROJECT ID        | admin                                                                                            |
@@ -744,7 +744,7 @@ Get information about a specific dataset.
     | VERSION           | v1.0alpha                                                                                     |
     | NUMBER OF COLUMNS | 794                                                                                           |
     | NUMBER OF ROWS    | 60000                                                                                         |
-    | DESCRIPTION       | {"label":{"end_column":794,"start_column":784},"picture":{"end_column":784,"start_column":0}} |
+    | DESCRIPTION       | {"label":{"column_end":794,"column_start":784},"picture":{"column_end":784,"column_start":0}} |
     | VISIBILITY        | private                                                                                       |
     | OWNER ID          | asdf                                                                                          |
     | PROJECT ID        | admin                                                                                         |
@@ -1352,13 +1352,21 @@ Create a new task to train the cluster with the data of a dataset, which was upl
 === "CLI"
 
     ```bash
-    hanamictl task create train -j -i <INPUT_HEXAGON_NAME>:<INPUT_DATASET_UUID> -o <LABEL_HEXAGON_NAME>:<LABEL_DATASET_UUID> -c <CLUSTER_UUID> <TASK_NAME>
+    hanamictl task create train -j \
+    -i <INPUT_DATASET_UUID>:<INPUT_DATASET_COLUMN_NAME>:<INPUT_HEXAGON_NAME> \
+    -o <LABEL_DATASET_UUID>:<LABEL_DATASET_COLUMN_NAME>:<LABEL_HEXAGON_NAME> \
+    -c <CLUSTER_UUID> \
+    <TASK_NAME>
     ```
 
     example:
 
     ```bash
-    hanamictl task create train -j -i picture:b03d1682-8f5b-48cb-bff5-08b67e8de6fe -o label:b833ddbe-55db-49d5-97b7-771293505493 -c 9f86921d-9a7c-44a2-836c-1683928d9354 cli_train_test_task
+    hanamictl task create train -j \
+    -i b03d1682-8f5b-48cb-bff5-08b67e8de6fe:picture:picture_hexagon \
+    -o b833ddbe-55db-49d5-97b7-771293505493:label:label_hexagon \
+    -c 9f86921d-9a7c-44a2-836c-1683928d9354 \
+    cli_train_test_task
 
     +------------------------+--------------------------------------+
     | UUID                   | 2e28e3bb-af45-4fbc-8ce3-c0c9a8e704bc |
@@ -1379,12 +1387,22 @@ Create a new task to train the cluster with the data of a dataset, which was upl
     address = "http://127.0.0.1:11418"
     task_name = "test_task"
     cluster_uuid = "9f86921d-9a7c-44a2-836c-1683928d9354"
-    inputs = {
-        "picture": "6f2bbcd2-7081-4b08-ae1d-16e6cd6f54c4"
-    }
-    outputs = {
-        "label": "6f2bbcd2-7081-4b08-ae1d-16e6cd6f54c4"
-    }
+    inputs = [
+        {
+            "dataset_uuid": "6f2bbcd2-7081-4b08-ae1d-16e6cd6f54c4",
+            "dataset_column": "picture",
+            "hexagon_name": "picture_hex"
+        }
+    ]
+
+    outputs = [
+        {
+            "dataset_uuid": "6f2bbcd2-7081-4b08-ae1d-16e6cd6f54c4",
+            "dataset_column": "label",
+            "hexagon_name": "label_hex"
+        }
+    ]
+
 
     # inputs and outputs are maps with key-value-pairs,
     # where the key is the name of the hexagon of the matching
@@ -1419,13 +1437,21 @@ used, which had to be uplaoded first.
 === "CLI"
 
     ```bash
-    hanamictl task create request -j -i <INPUT_HEXAGON_NAME>:<INPUT_DATASET_UUID> -r <OUTPUT_HEXAGON_NAME>:<OUTPUT_DATASET_NAME> -c <CLUSTER_UUID> <TASK_NAME>
+    hanamictl task create request -j \
+    -i <INPUT_DATASET_UUID>:<INPUT_DATASET_COLUMN_NAME>:<INPUT_HEXAGON_NAME> \
+    -r <OUTPUT_HEXAGON_NAME>:<OUTPUT_DATASET_COLUMN_NAME> \
+    -c <CLUSTER_UUID> \
+    <TASK_NAME>
     ```
 
     example:
 
     ```bash
-    hanamictl task create train -j -i picture:b03d1682-8f5b-48cb-bff5-08b67e8de6fe -r label:output_dataset -c 9f86921d-9a7c-44a2-836c-1683928d9354 cli_train_test_task
+    hanamictl task create train -j \
+    -i b03d1682-8f5b-48cb-bff5-08b67e8de6fe:picture:picture_hexagon \
+    -r label_hexagon:output_data \
+    -c 9f86921d-9a7c-44a2-836c-1683928d9354 \
+    cli_train_test_task
 
     +------------------------+--------------------------------------+
     | UUID                   | ec964017-ee19-4775-8fff-4f3fb3640361 |
@@ -1446,13 +1472,21 @@ used, which had to be uplaoded first.
     address = "http://127.0.0.1:11418"
     task_name = "test_task"
     cluster_uuid = "9f86921d-9a7c-44a2-836c-1683928d9354"
-    inputs = {
-        "picture": "6f2bbcd2-7081-4b08-ae1d-16e6cd6f54c4"
-    }
+    inputs = [
+        {
+            "dataset_uuid": "6f2bbcd2-7081-4b08-ae1d-16e6cd6f54c4",
+            "dataset_column": "picture",
+            "hexagon_name": "picture_hex"
+        }
+    ]
 
-    results = {
-        "label": "test_output"
-    }
+    results = [
+        {
+            "dataset_column": "test_output",
+            "hexagon_name": "label_hex"
+        }
+    ]
+
 
     # inputs and results are maps with key-value-pairs,
     # where the key is the name of the hexagon of the matching

--- a/docs/frontend/example_workflow.md
+++ b/docs/frontend/example_workflow.md
@@ -73,7 +73,7 @@ directly with the neural network via the python-version of the SDK. See for furt
           | VERSION           | v1.alpha                                                                                      |
           | NUMBER OF COLUMNS | 794                                                                                           |
           | NUMBER OF ROWS    | 60000                                                                                         |
-          | DESCRIPTION       | {"label":{"end_column":794,"start_column":784},"picture":{"end_column":784,"start_column":0}} |
+          | DESCRIPTION       | {"label":{"column_end":794,"column_start":784},"picture":{"column_end":784,"column_start":0}} |
           | VISIBILITY        | private                                                                                       |
           | OWNER ID          | asdf                                                                                          |
           | PROJECT ID        | admin                                                                                         |
@@ -87,7 +87,7 @@ directly with the neural network via the python-version of the SDK. See for furt
           | VERSION           | v1.alpha                                                                                      |
           | NUMBER OF COLUMNS | 794                                                                                           |
           | NUMBER OF ROWS    | 10000                                                                                         |
-          | DESCRIPTION       | {"label":{"end_column":794,"start_column":784},"picture":{"end_column":784,"start_column":0}} |
+          | DESCRIPTION       | {"label":{"column_end":794,"column_start":784},"picture":{"column_end":784,"column_start":0}} |
           | VISIBILITY        | private                                                                                       |
           | OWNER ID          | asdf                                                                                          |
           | PROJECT ID        | admin                                                                                         |
@@ -130,10 +130,10 @@ directly with the neural network via the python-version of the SDK. See for furt
         3,1,1
 
     inputs:
-        picture: 1,1,1
+        picture_hexagon: 1,1,1
 
     outputs:
-        label: 3,1,1
+        label_hexagon: 3,1,1
     ```
 
     !!! info
@@ -163,7 +163,11 @@ directly with the neural network via the python-version of the SDK. See for furt
 -   create task to train the cluster
 
     ```bash
-    ./hanamictl task create train --insecure -i picture:<UUID_OF_THE_TRAIN_DATASET> -o label:<UUID_OF_THE_TRAIN_DATASET> -c <UUID_OF_THE_CLUSTER> train_task
+    ./hanamictl task create train --insecure \
+    -i <UUID_OF_THE_TRAIN_DATASET>:picture:picture_hexagon \
+    -o <UUID_OF_THE_TRAIN_DATASET>:label:label_hexagon \
+    -c <UUID_OF_THE_CLUSTER> \
+    train_task
     ```
 
     !!! info
@@ -173,7 +177,12 @@ directly with the neural network via the python-version of the SDK. See for furt
     !!! example
 
           ```bash
-          ./hanamictl task create train --insecure -i picture:423ba6da-ca2a-4603-81bb-300326a10176 -o label:423ba6da-ca2a-4603-81bb-300326a10176 -c c495c0dd-2b4e-4a95-b533-fb9eb19c4ce4 train_task
+          ./hanamictl task create train --insecure \
+          -i 423ba6da-ca2a-4603-81bb-300326a10176:picture:picture_hexagon \
+          -o 423ba6da-ca2a-4603-81bb-300326a10176:label:label_hexagon \
+          -c c495c0dd-2b4e-4a95-b533-fb9eb19c4ce4 \
+          train_task
+
           +------------------------+--------------------------------------+
           | UUID                   | ae28638c-6856-439e-af3b-71ae509363e9 |
           | STATE                  | queued                               |
@@ -213,7 +222,11 @@ directly with the neural network via the python-version of the SDK. See for furt
 -   create task to test the cluster
 
     ```bash
-    ./hanamictl task create request --insecure -i picture:<UUID_OF_THE_TEST_DATASET> -r label:test_output -c <UUID_OF_THE_CLUSTER> test_task
+    ./hanamictl task create request --insecure \
+    -i <UUID_OF_THE_TEST_DATASET>:picture:picture_hexagon \
+    -r label_hexagon:test_output \
+    -c <UUID_OF_THE_CLUSTER> \
+    test_task
     ```
 
     It will create a new dataset with name `test_output` where the output of the task is written
@@ -222,7 +235,12 @@ directly with the neural network via the python-version of the SDK. See for furt
     !!! example
 
           ```bash
-          ./hanamictl task create request --insecure -i picture:a42dce48-d4b6-40f9-a8d8-0c22d48e2a4d -r label:test_output -c c495c0dd-2b4e-4a95-b533-fb9eb19c4ce4 test_task
+          ./hanamictl task create request --insecure \
+          -i a42dce48-d4b6-40f9-a8d8-0c22d48e2a4d:picture:picture_hexagon \
+          -r label_hexagon:test_output \
+          -c c495c0dd-2b4e-4a95-b533-fb9eb19c4ce4 \
+          test_task
+          
           +------------------------+--------------------------------------+
           | UUID                   | 36f70489-c71c-48d7-9e08-a766507df5de |
           | STATE                  | queued                               |

--- a/docs/inner_workings/core/core.md
+++ b/docs/inner_workings/core/core.md
@@ -24,7 +24,7 @@ There are different types of hexagons: input, output and internal (hidden). At t
 creating a new cluster, there are no neurons (nodes) or connections between the neurons defined.
 Everything is created at runtime while training the cluster. While this happens, the hexagons are
 working like a plant trellis for the connections. The hexagon-structure was introduced as based for
-the experimental [layer-less](inner_workings/core/core/#no-strict-layer-structure) structure.
+the experimental [layer-less](/inner_workings/core/core/#no-strict-layer-structure) structure.
 
 !!! info
 
@@ -301,9 +301,13 @@ neurons within another hexagon, to avoid race-conditions.
 
 There are some even more experimental optional features, which can be enabled. They can be defined
 in the [cluster-templates](/frontend/cluster_templates/cluster_template/). There are also a few
-[measurement-examples](/inner_workings/measurements/measurements/#reduction_1).
+[measurement-examples](/inner_workings/measurements/measurements).
 
 ### Reduction
+
+!!! info
+
+    The reduction-process is currently disables, because of changes in the growing process.
 
 The reduction-process should limit the size of the neural network, by deleting nearly never used
 synapses again, which were not capable of reaching the necessary threshold to be persistent.

--- a/docs/inner_workings/measurements/measurements.md
+++ b/docs/inner_workings/measurements/measurements.md
@@ -1,5 +1,9 @@
 # Optional features and Measurements
 
+!!! info
+
+    The following tests were made with version 0.4.0 and not repeated with newer versions so far, even the cluster-templates of the examples were updated here. So the results can differ in there current state. Test tests here will be repeated in the near future. 
+
 These are some measurements, which were done with the program on version 0.4.0, to get a basic
 overview of the capabilities and limitations so far.
 

--- a/src/hanami/src/api/http/dataset/check_dataset_v1_0.cpp
+++ b/src/hanami/src/api/http/dataset/check_dataset_v1_0.cpp
@@ -83,10 +83,10 @@ CheckMnistDataSetV1M0::runTask(BlossomIO& blossomIO,
     }
 
     // set file-selectors
-    datasetFileHandle.readSelector.endColumn = 10;
+    datasetFileHandle.readSelector.columnEnd = 10;
     datasetFileHandle.readSelector.endRow = 10000;
-    referenceFileHandle.readSelector.startColumn = 784;
-    referenceFileHandle.readSelector.endColumn = 794;
+    referenceFileHandle.readSelector.columnStart = 784;
+    referenceFileHandle.readSelector.columnEnd = 794;
     referenceFileHandle.readSelector.endRow = 10000;
 
     // init buffer for output

--- a/src/hanami/src/api/http/dataset/csv/finalize_csv_dataset_v1_0.cpp
+++ b/src/hanami/src/api/http/dataset/csv/finalize_csv_dataset_v1_0.cpp
@@ -194,8 +194,8 @@ FinalizeCsvDataSetV1M0::convertCsvData(const std::string& filePath,
             uint64_t counter = 0;
             for (const std::string& colName : lineContent) {
                 json inputDescrEntry;
-                inputDescrEntry["start_column"] = counter;
-                inputDescrEntry["end_column"] = counter + 1;
+                inputDescrEntry["column_start"] = counter;
+                inputDescrEntry["column_end"] = counter + 1;
                 description[colName] = inputDescrEntry;
                 counter++;
             }

--- a/src/hanami/src/api/http/dataset/download_dataset_content_v1_0.cpp
+++ b/src/hanami/src/api/http/dataset/download_dataset_content_v1_0.cpp
@@ -96,14 +96,14 @@ DownloadDatasetContentV1M0::runTask(BlossomIO& blossomIO,
 
     // set file-selectors
     const json range = datasetFileHandle.description[columnName];
-    datasetFileHandle.readSelector.startColumn = range["start_column"];
-    datasetFileHandle.readSelector.endColumn = range["end_column"];
+    datasetFileHandle.readSelector.columnStart = range["column_start"];
+    datasetFileHandle.readSelector.columnEnd = range["column_end"];
     datasetFileHandle.readSelector.startRow = rowOffset;
     datasetFileHandle.readSelector.endRow = rowOffset + numberOfRows;
 
     // init buffer for output
     const uint64_t numberOfColumns
-        = datasetFileHandle.readSelector.endColumn - datasetFileHandle.readSelector.startColumn;
+        = datasetFileHandle.readSelector.columnEnd - datasetFileHandle.readSelector.columnStart;
     std::vector<float> datasetOutput(numberOfColumns, 0.0f);
     blossomIO.output["data"] = json::array();
 

--- a/src/hanami/src/api/http/dataset/mnist/finalize_mnist_dataset_v1_0.cpp
+++ b/src/hanami/src/api/http/dataset/mnist/finalize_mnist_dataset_v1_0.cpp
@@ -179,12 +179,12 @@ FinalizeMnistDataSetV1M0::convertMnistData(const std::string& filePath,
     // create description
     json description;
     json inputDescrEntry;
-    inputDescrEntry["start_column"] = 0;
-    inputDescrEntry["end_column"] = pictureSize;
+    inputDescrEntry["column_start"] = 0;
+    inputDescrEntry["column_end"] = pictureSize;
     description["picture"] = inputDescrEntry;
     json outputDescrEntry;
-    outputDescrEntry["start_column"] = pictureSize;
-    outputDescrEntry["end_column"] = pictureSize + 10;
+    outputDescrEntry["column_start"] = pictureSize;
+    outputDescrEntry["column_end"] = pictureSize + 10;
     description["label"] = outputDescrEntry;
 
     // initialize file

--- a/src/hanami/src/api/http/task/create_request_task_v1_0.h
+++ b/src/hanami/src/api/http/task/create_request_task_v1_0.h
@@ -42,18 +42,18 @@ class CreateRequestTaskV1M0 : public Blossom
    private:
     ReturnStatus fillTaskIo(DataSetFileHandle& fileHandle,
                             const Hanami::UserContext& userContext,
-                            const std::string& hexagonName,
+                            const std::string& columnName,
                             const std::string& datasetUuid,
                             BlossomStatus& status,
                             Hanami::ErrorContainer& error);
 
-    ReturnStatus createResultTarget(DataSetFileHandle& fileHandle,
-                                    const std::string& datasetUuid,
-                                    const std::string& name,
-                                    const Hanami::UserContext& userContext,
-                                    const uint64_t numberOfOutputs,
-                                    BlossomStatus& status,
-                                    Hanami::ErrorContainer& error);
+    ReturnStatus createResultDataset(Cluster* cluster,
+                                     Task* task,
+                                     const std::string& datasetName,
+                                     const json& resultMetaData,
+                                     const Hanami::UserContext& userContext,
+                                     BlossomStatus& status,
+                                     Hanami::ErrorContainer& error);
 };
 
 #endif  // CREATEREQUESTTASK_H

--- a/src/hanami/src/api/http/task/create_train_task_v1_0.h
+++ b/src/hanami/src/api/http/task/create_train_task_v1_0.h
@@ -42,7 +42,7 @@ class CreateTrainTaskV1M0 : public Blossom
    private:
     ReturnStatus fillTaskIo(DataSetFileHandle& taskIo,
                             const Hanami::UserContext& userContext,
-                            const std::string& hexagonName,
+                            const std::string& columnName,
                             const std::string& settings,
                             BlossomStatus& status,
                             Hanami::ErrorContainer& error);

--- a/src/hanami/src/core/io/data_set/dataset_file_io.h
+++ b/src/hanami/src/core/io/data_set/dataset_file_io.h
@@ -54,6 +54,13 @@ ReturnStatus initNewDataSetFile(DataSetFileHandle& result,
                                 const uint64_t numberOfColumns,
                                 Hanami::ErrorContainer& error);
 
+ReturnStatus initNewDataSetFile(const std::string& filePath,
+                                const std::string& name,
+                                const json& description,
+                                const DataSetType type,
+                                const uint64_t numberOfColumns,
+                                Hanami::ErrorContainer& error);
+
 ReturnStatus appendToDataSet(DataSetFileHandle& fileHandle,
                              const void* input,
                              const uint64_t inputSize,
@@ -75,8 +82,8 @@ ReturnStatus _fillDataSetReadBuffer(DataSetFileHandle& fileHandle,
 struct DataSetSelector {
     uint64_t startRow = 0;
     uint64_t endRow = 0;
-    uint64_t startColumn = 0;
-    uint64_t endColumn = 0;
+    uint64_t columnStart = 0;
+    uint64_t columnEnd = 0;
 
     DataSetSelector() {}
 
@@ -85,15 +92,15 @@ struct DataSetSelector {
         if (input.contains("start_row")) {
             startRow = input["start_row"];
         }
-        if (input.contains("start_column")) {
-            startColumn = input["start_column"];
+        if (input.contains("column_start")) {
+            columnStart = input["column_start"];
         }
 
-        if (input.contains("end_column") == false) {
+        if (input.contains("column_end") == false) {
             return INVALID_INPUT;
         }
 
-        endColumn = input["end_column"];
+        columnEnd = input["column_end"];
 
         return OK;
     }
@@ -302,7 +309,7 @@ _convert(std::vector<OUT_T>& result, const DataSetFileHandle& fileHandle, const 
 {
     const IN_T* data = static_cast<const IN_T*>(fileHandle.readBuffer.data);
     uint64_t counter = 0;
-    for (uint64_t x = fileHandle.readSelector.startColumn; x < fileHandle.readSelector.endColumn;
+    for (uint64_t x = fileHandle.readSelector.columnStart; x < fileHandle.readSelector.columnEnd;
          x++)
     {
         result[counter] = static_cast<OUT_T>(data[(byteOffset / sizeof(IN_T)) + x]);
@@ -341,8 +348,8 @@ getDataFromDataSet(std::vector<T>& result,
     }
 
     // check ranges
-    if (fileHandle.readSelector.endColumn > fileHandle.header.numberOfColumns
-        || fileHandle.readSelector.startColumn > fileHandle.header.numberOfColumns)
+    if (fileHandle.readSelector.columnEnd > fileHandle.header.numberOfColumns
+        || fileHandle.readSelector.columnStart > fileHandle.header.numberOfColumns)
     {
         return INVALID_INPUT;
     }
@@ -358,7 +365,7 @@ getDataFromDataSet(std::vector<T>& result,
     }
 
     // check if given buffer is big enough
-    if (result.size() < fileHandle.readSelector.endColumn - fileHandle.readSelector.startColumn) {
+    if (result.size() < fileHandle.readSelector.columnEnd - fileHandle.readSelector.columnStart) {
         return INVALID_INPUT;
     }
 

--- a/src/hanami/tests/unit_tests/core/dataset_io_test.cpp
+++ b/src/hanami/tests/unit_tests/core/dataset_io_test.cpp
@@ -108,8 +108,8 @@ DataSetIO_Test::read_test()
 
     std::vector<float> output(3, 0.0f);
     DataSetSelector selector;
-    selector.startColumn = 1;
-    selector.endColumn = 3;
+    selector.columnStart = 1;
+    selector.columnEnd = 3;
     selector.endRow = 3;
     fileHandle.readSelector = selector;
 

--- a/src/sdk/go/hanami_sdk/task.go
+++ b/src/sdk/go/hanami_sdk/task.go
@@ -20,43 +20,56 @@
 
 package hanami_sdk
 
-import (
-	"strings"
-)
-
-func convertIO(data []string) map[string]string {
-	valueMap := make(map[string]string)
-
-	for _, val := range data {
-		parts := strings.Split(val, ":")
-		if len(parts) != 2 {
-			break
-		}
-		valueMap[parts[0]] = parts[1]
-	}
-
-	return valueMap
+type TaskInput struct {
+	HexagonName        string `json:"hexagon_name"`
+	DatasetColumnName  string `json:"dataset_column"`
+	DatasetUuid        string `json:"dataset_uuid"`
 }
 
-func CreateTrainTask(address, token, name, clusterUuid string, inputs, outputs []string, timeLenght int, skipTlsVerification bool) (map[string]interface{}, error) {
+type TaskResult struct {
+	HexagonName        string `json:"hexagon_name"`
+	DatasetColumnName  string `json:"dataset_column"`
+}
+
+func CreateTrainTask(address, token, name, clusterUuid string, inputs, outputs []TaskInput, timeLenght int, skipTlsVerification bool) (map[string]interface{}, error) {
+    var inputArray []interface{}
+    for _, input := range inputs {
+        inputArray = append(inputArray, input)
+    }
+
+    var outputArray []interface{}
+    for _, output := range outputs {
+        outputArray = append(outputArray, output)
+    }
+
 	path := "v1.0alpha/task/train"
 	jsonBody := map[string]interface{}{
 		"name":         name,
 		"cluster_uuid": clusterUuid,
-		"inputs":       convertIO(inputs),
-		"outputs":      convertIO(outputs),
+		"inputs":       inputArray,
+		"outputs":      outputArray,
 		"time_length":  timeLenght,
 	}
 	return SendPost(address, token, path, jsonBody, skipTlsVerification)
 }
 
-func CreateRequestTask(address, token, name, clusterUuid string, inputs, results []string, timeLenght int, skipTlsVerification bool) (map[string]interface{}, error) {
+func CreateRequestTask(address, token, name, clusterUuid string, inputs []TaskInput, results []TaskResult, timeLenght int, skipTlsVerification bool) (map[string]interface{}, error) {
+	var inputArray []interface{}
+    for _, input := range inputs {
+        inputArray = append(inputArray, input)
+    }
+
+    var resultArray []interface{}
+    for _, result := range results {
+        resultArray = append(resultArray, result)
+    }
+
 	path := "v1.0alpha/task/request"
 	jsonBody := map[string]interface{}{
 		"name":         name,
 		"cluster_uuid": clusterUuid,
-		"inputs":       convertIO(inputs),
-		"results":      convertIO(results),
+		"inputs":       inputArray,
+		"results":      resultArray,
 		"time_length":  timeLenght,
 	}
 	return SendPost(address, token, path, jsonBody, skipTlsVerification)

--- a/src/sdk/python/hanami_sdk/hanami_sdk/task.py
+++ b/src/sdk/python/hanami_sdk/hanami_sdk/task.py
@@ -20,8 +20,8 @@ def create_train_task(token: str,
                       address: str,
                       name: str,
                       cluster_uuid: str,
-                      inputs: dict,
-                      outputs: dict,
+                      inputs: list,
+                      outputs: list,
                       timeLength: int = 1,
                       verify_connection: bool = True) -> str:
     path = "/v1.0alpha/task/train"
@@ -44,8 +44,8 @@ def create_request_task(token: str,
                         address: str,
                         name: str,
                         cluster_uuid: str,
-                        inputs: dict,
-                        results: dict,
+                        inputs: list,
+                        results: list,
                         timeLength: int = 1,
                         verify_connection: bool = True) -> str:
     path = "/v1.0alpha/task/request"

--- a/testing/go_cli_api/cli_test.sh
+++ b/testing/go_cli_api/cli_test.sh
@@ -4,14 +4,14 @@
 # export HANAMI_USER=asdf
 # export HANAMI_PW=asdfasdf
 
-# export train_inputs=/tmp/train-images-idx3-ubyte
-# export train_labels=/tmp/train-labels-idx1-ubyte
-# export request_inputs=/tmp/t10k-images-idx3-ubyte
-# export request_labels=/tmp/t10k-labels-idx1-ubyte
+# export train_inputs=/home/neptune/Schreibtisch/mnist/train-images.idx3-ubyte
+# export train_labels=/home/neptune/Schreibtisch/mnist/train-labels.idx1-ubyte
+# export request_inputs=/home/neptune/Schreibtisch/mnist/t10k-images.idx3-ubyte
+# export request_labels=/home/neptune/Schreibtisch/mnist/t10k-labels.idx1-ubyte
 
 
 # build protobuffer for go sdk
-# pushd ../../src/sdk/go/hanami_sdk 
+# pushd ../../src/sdk/go/hanami_sdk
 # protoc --go_out=. --proto_path ../../../libraries/hanami_messages/protobuffers hanami_messages.proto3
 # popd
 
@@ -74,7 +74,8 @@ echo "Cluster-UUID: $cluster_uuid"
 
 
 # train test
-task_uuid=$(./hanamictl task create train --insecure -j -i picture:$train_dataset_uuid -o label:$train_dataset_uuid -c $cluster_uuid cli_train_test_task | jq -r '.uuid')
+echo "./hanamictl task create train --insecure -j -i $train_dataset_uuid:picture:picture_hex -o $train_dataset_uuid:label:label_hex -c $cluster_uuid cli_train_test_task"
+task_uuid=$(./hanamictl task create train --insecure -j -i $train_dataset_uuid:picture:picture_hex -o $train_dataset_uuid:label:label_hex -c $cluster_uuid cli_train_test_task | jq -r '.uuid')
 echo "Train-Task-UUID: $task_uuid"
 
 while true; do
@@ -102,7 +103,8 @@ echo "new Cluster-UUID: $cluster_uuid"
 ./hanamictl cluster restore --insecure -c $checkpoint_uuid $cluster_uuid
 
 # request test
-req_task_uuid=$(./hanamictl task create request --insecure -j -i picture:$request_dataset_uuid -r label:cli_test_output -c $cluster_uuid cli_request_test_task | jq -r '.uuid')
+echo "./hanamictl task create request --insecure -j -i $request_dataset_uuid:picture:picture_hex -r label_hex:cli_test_output -c $cluster_uuid cli_request_test_task"
+req_task_uuid=$(./hanamictl task create request --insecure -j -i $request_dataset_uuid:picture:picture_hex -r label_hex:cli_test_output -c $cluster_uuid cli_request_test_task | jq -r '.uuid')
 echo "Request-Task-UUID: $req_task_uuid"
 
 ./hanamictl task list --insecure -c $cluster_uuid 
@@ -123,7 +125,7 @@ done
 ./hanamictl dataset list --insecure
 
 
-result_uuid=$(./hanamictl dataset list --insecure -j | jq -r '.body[] | select(.[-1] == "cli_test_output") | .[1]')
+result_uuid=$(./hanamictl dataset list --insecure -j | jq -r '.body[] | select(.[-1] == "cli_request_test_task") | .[1]')
 echo "Result-Dataset-UUID: $result_uuid"
 
 ./hanamictl dataset get --insecure $result_uuid

--- a/testing/go_cli_api/cluster_template
+++ b/testing/go_cli_api/cluster_template
@@ -10,7 +10,7 @@ hexagons:
     3,1,1
     
 inputs:
-    picture: 1,1,1
+    picture_hex: 1,1,1
 
 outputs:
-    label: 3,1,1
+    label_hex: 3,1,1

--- a/testing/python_sdk_api/sdk_api_test.py
+++ b/testing/python_sdk_api/sdk_api_test.py
@@ -63,10 +63,10 @@ cluster_template = \
     "    3,1,1\n" \
     "    \n" \
     "inputs:\n" \
-    "    picture: 1,1,1\n" \
+    "    picture_hex: 1,1,1\n" \
     "\n" \
     "outputs:\n" \
-    "    label: 3,1,1\n" \
+    "    label_hex: 3,1,1\n" \
 
 user_id = "tsugumi"
 user_name = "Tsugumi"
@@ -221,19 +221,19 @@ async def test_direct_io(token, address, cluster_uuid):
     ws = await cluster.switch_to_direct_mode(token, address, cluster_uuid, False)
     for i in range(0, 100):
         await direct_io.send_train_input(ws,
-                                         "picture",
+                                         "picture_hex",
                                          test_values.get_direct_io_test_intput(),
                                          True,
                                          False,
                                          False)
         await direct_io.send_train_input(ws,
-                                         "label",
+                                         "label_hex",
                                          test_values.get_direct_io_test_output(),
                                          False,
                                          True,
                                          False)
     output_values = await direct_io.send_request_input(ws,
-                                                       "picture",
+                                                       "picture_hex",
                                                        test_values.get_direct_io_test_intput(),
                                                        True,
                                                        False)
@@ -264,13 +264,21 @@ def test_workflow():
         cluster.switch_host(token, address, cluster_uuid, target_host_uuid, False)
 
     # run training
-    inputs = {
-        "picture": train_dataset_uuid
-    }
+    inputs = [
+        {
+            "dataset_uuid": train_dataset_uuid,
+            "dataset_column": "picture",
+            "hexagon_name": "picture_hex"
+        }
+    ]
 
-    outputs = {
-        "label": train_dataset_uuid
-    }
+    outputs = [
+        {
+            "dataset_uuid": train_dataset_uuid,
+            "dataset_column": "label",
+            "hexagon_name": "label_hex"
+        }
+    ]
 
     for i in range(0, 1):
         result = task.create_train_task(
@@ -309,13 +317,20 @@ def test_workflow():
         pass
 
     # run testing
-    inputs = {
-        "picture": request_dataset_uuid
-    }
+    inputs = [
+        {
+            "dataset_uuid": request_dataset_uuid,
+            "dataset_column": "picture",
+            "hexagon_name": "picture_hex"
+        }
+    ]
 
-    results = {
-        "label": "test_output"
-    }
+    results = [
+        {
+            "dataset_column": "test_output",
+            "hexagon_name": "label_hex"
+        }
+    ]
 
     result = task.create_request_task(
         token, address, generic_task_name, cluster_uuid, inputs, results, 1, False)


### PR DESCRIPTION

## Pull Request

### Description

The way to define inputs for tasks was updated
in order to remove the restriction, that hexagons
must have the same name like the used column in
the dataset. Now they can have different names.

<!-- A concise description of the content of the pull-request -->

### Related Issues

- #439 
<!-- In context of which issues the changes of this pull request were created. -->

### How it was tested?

- CI-pipeline and manually test with SDK- and CLI-test
<!-- What parts and how they were tested -->
