### PR TITLE
fix: fix arm-build in CI

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -864,7 +864,7 @@ jobs:
       matrix:
         platform:
           - linux/amd64
-          # - linux/arm64
+          - linux/arm64
     steps:
       - 
         name: Prepare


### PR DESCRIPTION


## Pull Request

### Description

The arm64 docker build was disabled in the previous commit and forgot to re-enable again.
<!-- A concise description of the content of the pull-request -->

### Related Issues

<!-- In context of which issues the changes of this pull request were created. -->

### How it was tested?

<!-- What parts and how they were tested -->
