### PR TITLE
feat(#420): mark some helm-values as required

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -1129,7 +1129,7 @@ jobs:
       -
         name: Install hanami
         run: |
-          helm install --set docker.tag="${{ env.BRANCH_NAME }}" --set user.id=asdf --set user.name="test user" --set user.passphrase="asdfasdf" --set token.passphrase="this is a test-token" --set api.domain=local-hanami  openhanami /tmp/hanami_helm_build_result/openhanami-$HELM_VERSION.tgz
+          helm install --set docker.tag="${{ env.BRANCH_NAME }}" --set user.id=asdf --set user.name="test user" --set user.passphrase="asdfasdf" --set token.data="this is a test-token" --set api.domain=local-hanami  openhanami /tmp/hanami_helm_build_result/openhanami-$HELM_VERSION.tgz
       - 
         name: Sleep for 60 seconds
         uses: jakejarvis/wait-action@919fc193e07906705e5b7a50f90ea9e74d20b2b0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 - item-buffer was internally changed to be more compatible for further attempts of GPU-support
 - made internal processing more generic, to have the same worker-workflow for all coming backends
 - use debug builds with ASan-check for tests of the CI (unit-, functional-, memory-leak-, sdk-api- and cli-api-tests)
+- default-values for initial admin-credentials and token-key were removed from the helm-chart and are now marked as required
 
 ### Fixed
 

--- a/deploy/k8s/openhanami/templates/hanami-deployment.yaml
+++ b/deploy/k8s/openhanami/templates/hanami-deployment.yaml
@@ -39,11 +39,11 @@ spec:
         imagePullPolicy: Always
         env:
         - name: HANAMI_ADMIN_USER_ID
-          value: {{ .Values.user.id }}
+          value: {{ required "user.id is required!" .Values.user.id }}
         - name: HANAMI_ADMIN_USER_NAME
-          value: {{ .Values.user.name }}
+          value: {{ required "user.name is required!" .Values.user.name }}
         - name: HANAMI_ADMIN_PASSPHRASE
-          value: {{ .Values.user.passphrase }}
+          value: {{ required "user.passphrase is required!" .Values.user.passphrase }}
         volumeMounts:
         - name: data-volume
           mountPath: /etc/openhanami/data/

--- a/deploy/k8s/openhanami/templates/token-key.yaml
+++ b/deploy/k8s/openhanami/templates/token-key.yaml
@@ -4,4 +4,4 @@ metadata:
   name: token-key
 type: Opaque
 data:
-  token-key: {{ .Values.token.data | b64enc }}
+  token-key: {{ required "token.data is required!" .Values.token.data | b64enc }}

--- a/deploy/k8s/openhanami/values.yaml
+++ b/deploy/k8s/openhanami/values.yaml
@@ -2,12 +2,12 @@
 replicaCount: 1
 
 user:
-  id: "test_user"
-  name: "Test User"
-  passphrase: "asdfasdf"
+  id: ""
+  name: ""
+  passphrase: ""
 
 token:
-  data: "asdf"
+  data: ""
   expire_time: 3600
 
 docker:

--- a/docs/backend/installation.md
+++ b/docs/backend/installation.md
@@ -133,7 +133,7 @@ helm install \
     --set user.id=USER_ID  \
     --set user.name=USER_NAME  \
     --set user.passphrase=PASSPHRASE  \
-    --set token.passphrase=TOKEN_KEY  \
+    --set token.data=TOKEN_KEY  \
     --set api.domain=DOMAIN_NAME  \
     openhanami \
     ./openhanami/
@@ -149,7 +149,7 @@ helm install \
     --set user.id=USER_ID  \
     --set user.name=USER_NAME  \
     --set user.passphrase=PASSPHRASE  \
-    --set token.passphrase=TOKEN_KEY  \
+    --set token.data=TOKEN_KEY  \
     --set api.domain=DOMAIN_NAME  \
     openhanami \
     openhanami-x.y.z.tgz
@@ -159,35 +159,41 @@ The `--set`-flag defining the login-information for the initial admin-user of th
 
 -   `USER_ID`
 
+    -   **required**
     -   Identifier for the new user. It is used for login and internal references to the user.
     -   String, which MUST match the regex `[a-zA-Z][a-zA-Z_0-9@]*` with between `4` and `256`
         characters length
 
 -   `USER_NAME`
 
+    -   **required**
     -   Better readable name for the user, which doesn't have to be unique in the system.
     -   String, which MUST match the regex `[a-zA-Z][a-zA-Z_0-9 ]*` with between `4` and `256`
         characters length
 
 -   `PASSPHRASE`
 
+    -   **required**
     -   Passphrase for the initial user
     -   String, with between `8` and `4096` characters length
 
 -   `TOKEN_KEY`
 
+    -   **required**
     -   Key for the JWT-Tokens
     -   String
 
 -   `DOMAIN_NAME`
 
-    -   Domain for https-access. Per default it is `local-hanami`
+    -   Domain for https-access.
     -   String
+    -   default: *local-hanami*
 
 -   `DOCKER_IMAGE_TAG`
     -   Docker-tag used from
         [docker-hub](https://hub.docker.com/repository/docker/kitsudaiki/hanami/tags)
     -   String
+    -   default: *develop*
 
 After a successful installation the `USER_ID` and `PASSPHRASE` have to be used for login to the
 system.


### PR DESCRIPTION

## Pull Request

### Description
The default-values for the initial admin-credentials and the token-key were removed from the helm-chart and instead of this, these values are now marked as required to ensure that they were set explicit.
<!-- A concise description of the content of the pull-request -->

### Related Issues
- #420
<!-- In context of which issues the changes of this pull request were created. -->

### How it was tested?

- ci-pipeline with kubernetes-tests
- manually testing with missing values
<!-- What parts and how they were tested -->
