### PR TITLE
feat(#483): added some metrics to cluster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 
 - added new workaround to be able to handle binary input-data
 - added new output-modi to provide more output-options to combine multiple outputs bitwise into a bigger value
+- added metrics for number of blocks and number of sections to cluster get output
 
 ### Changed
 

--- a/docs/frontend/cli_sdk_docu.md
+++ b/docs/frontend/cli_sdk_docu.md
@@ -1096,14 +1096,16 @@ used memory and so on are still missing in this output currently.
     ```bash
     hanamictl cluster get 12959485-51a7-45bc-84dd-aad1c9bfd510
 
-    +------------+--------------------------------------+
-    | UUID       | 12959485-51a7-45bc-84dd-aad1c9bfd510 |
-    | NAME       | cli_test_cluster                     |
-    | VISIBILITY | private                              |
-    | OWNER ID   | asdf                                 |
-    | PROJECT ID | admin                                |
-    | CREATED AT | 2024-07-13 21:45:56                  |
-    +------------+--------------------------------------+
+    +--------------------+--------------------------------------+
+    | UUID               | 12959485-51a7-45bc-84dd-aad1c9bfd510 |
+    | NAME               | cli_test_cluster                     |
+    | VISIBILITY         | private                              |
+    | OWNER ID           | asdf                                 |
+    | NUMBER OF BLOCKS   | 3                                    |
+    | NUMBER OF SECTIONS | 973                                  |
+    | PROJECT ID         | admin                                |
+    | CREATED AT         | 2024-07-13 21:45:56                  |
+    +--------------------+--------------------------------------+
     ```
 
 === "Python-SDK"
@@ -1125,6 +1127,8 @@ used memory and so on are still missing in this output currently.
     #     "name": "test_cluster",
     #     "owner_id": "asdf",
     #     "project_id": "admin",
+    #     "number_of_blocks": 3,
+    #     "number_of_sections": 973,
     #     "uuid": "d94f2b53-f404-4215-9a33-63c4a03e3202",
     #     "visibility": "private"
     # }

--- a/src/cli/hanamictl/resources/cluster.go
+++ b/src/cli/hanamictl/resources/cluster.go
@@ -44,6 +44,17 @@ var clusterHeader = []string{
 	"created_at",
 }
 
+var clusterGetHeader = []string{
+	"uuid",
+	"name",
+	"visibility",
+	"owner_id",
+	"number_of_blocks",
+	"number_of_sections",
+	"project_id",
+	"created_at",
+}
+
 var clusterSaveHeader = []string{
 	"uuid",
 	"name",
@@ -88,7 +99,7 @@ var getClusterCmd = &cobra.Command{
 			fmt.Println(err)
 			os.Exit(1)
 		}
-		hanamictl_common.PrintSingle(content, clusterHeader)
+		hanamictl_common.PrintSingle(content, clusterGetHeader)
 	},
 }
 

--- a/src/hanami/src/api/http/cluster/show_cluster_v1_0.cpp
+++ b/src/hanami/src/api/http/cluster/show_cluster_v1_0.cpp
@@ -22,6 +22,8 @@
 
 #include "show_cluster_v1_0.h"
 
+#include <core/cluster/cluster.h>
+#include <core/cluster/cluster_handler.h>
 #include <database/cluster_table.h>
 #include <hanami_root.h>
 
@@ -57,6 +59,12 @@ ShowClusterV1M0::ShowClusterV1M0() : Blossom("Show information of a specific clu
     registerOutputField("visibility", SAKURA_STRING_TYPE)
         .setComment("Visibility of the cluster (private, shared, public).");
 
+    registerOutputField("number_of_blocks", SAKURA_INT_TYPE)
+        .setComment("Number of blocks in the cluster.");
+
+    registerOutputField("number_of_sections", SAKURA_INT_TYPE)
+        .setComment("Number of synapse-sections in the cluster.");
+
     //----------------------------------------------------------------------------------------------
     //
     //----------------------------------------------------------------------------------------------
@@ -87,6 +95,19 @@ ShowClusterV1M0::runTask(BlossomIO& blossomIO,
         LOG_DEBUG(status.errorMessage);
         return false;
     }
+
+    // get cluster
+    Cluster* cluster = ClusterHandler::getInstance()->getCluster(clusterUuid);
+    if (cluster == nullptr) {
+        status.statusCode = INTERNAL_SERVER_ERROR_RTYPE;
+        error.addMessage("Cluster with UUID '" + clusterUuid
+                         + "'not found even it exists within the database");
+        return false;
+    }
+
+    // add metrics to output
+    blossomIO.output["number_of_blocks"] = cluster->metrics.numberOfBlocks;
+    blossomIO.output["number_of_sections"] = cluster->metrics.numberOfSections;
 
     return true;
 }

--- a/src/hanami/src/core/cluster/cluster.h
+++ b/src/hanami/src/core/cluster/cluster.h
@@ -56,6 +56,7 @@ class Cluster
 
     // cluster-data
     ClusterHeader clusterHeader;
+    ClusterMetrics metrics;
 
     std::vector<Hexagon> hexagons;
     std::map<std::string, InputInterface> inputInterfaces;

--- a/src/hanami/src/core/cluster/objects.h
+++ b/src/hanami/src/core/cluster/objects.h
@@ -345,6 +345,13 @@ static_assert(sizeof(HexagonHeader) == 40);
 
 //==================================================================================================
 
+struct ClusterMetrics {
+    uint64_t numberOfBlocks = 0;
+    uint64_t numberOfSections = 0;
+};
+
+//==================================================================================================
+
 struct Hexagon {
     HexagonHeader header;
 

--- a/src/hanami/src/core/io/checkpoint/disc/checkpoint_io.cpp
+++ b/src/hanami/src/core/io/checkpoint/disc/checkpoint_io.cpp
@@ -121,6 +121,18 @@ CheckpointIO::restoreClusterFromFile(Cluster& cluster,
     // write original UUID back to the restored cluster
     strncpy(cluster.clusterHeader.uuid.uuid, originalUuid.c_str(), originalUuid.size());
 
+    // count number of blocks and sections within cluster
+    for (const Hexagon& hexagon : cluster.hexagons) {
+        for (const ConnectionBlock& connectionBlock : hexagon.connectionBlocks) {
+            cluster.metrics.numberOfBlocks++;
+            for (uint32_t i = 0; i < NUMBER_OF_SYNAPSESECTION; ++i) {
+                if (connectionBlock.connections[i].origin.blockId != UNINIT_STATE_16) {
+                    cluster.metrics.numberOfSections++;
+                }
+            }
+        }
+    }
+
     return OK;
 }
 

--- a/src/hanami/src/core/processing/cluster_resize.h
+++ b/src/hanami/src/core/processing/cluster_resize.h
@@ -85,26 +85,21 @@ searchTargetInHexagon(Hexagon* targetHexagon, ItemBuffer<SynapseBlock>& synapseB
 inline void
 resizeBlocks(Hexagon* targetHexagon)
 {
-    const uint32_t dimXold = targetHexagon->header.numberOfBlocks;
-
     targetHexagon->header.numberOfBlocks++;
 
     // resize list
     targetHexagon->connectionBlocks.resize(targetHexagon->header.numberOfBlocks);
     targetHexagon->synapseBlockLinks.resize(targetHexagon->header.numberOfBlocks);
+    targetHexagon->neuronBlocks.resize(targetHexagon->header.numberOfBlocks);
+    targetHexagon->cluster->metrics.numberOfBlocks++;
 
-    // if there was no scaling in x-dimension, then no re-ordering necessary
-    if (targetHexagon->header.numberOfBlocks == dimXold) {
-        return;
-    }
-    LOG_DEBUG("resized connection-Block: " + std::to_string(dimXold) + " -> "
-              + std::to_string(targetHexagon->header.numberOfBlocks));
+    LOG_DEBUG("resized blocks to: " + std::to_string(targetHexagon->header.numberOfBlocks));
 
     // update content of list for the new size
     targetHexagon->connectionBlocks[targetHexagon->header.numberOfBlocks - 1] = ConnectionBlock();
     targetHexagon->synapseBlockLinks[targetHexagon->header.numberOfBlocks - 1] = UNINIT_STATE_64;
+    targetHexagon->neuronBlocks[targetHexagon->header.numberOfBlocks - 1] = NeuronBlock();
 
-    targetHexagon->neuronBlocks.resize(targetHexagon->header.numberOfBlocks);
     targetHexagon->header.numberOfFreeSections += NUMBER_OF_SYNAPSESECTION;
 }
 
@@ -152,6 +147,7 @@ createNewSection(Cluster& cluster, Connection* sourceConnection)
     }
     targetHexagon->header.numberOfFreeSections--;
     targetHexagon->wasResized = true;
+    cluster.metrics.numberOfSections++;
 
     // initialize new connection
     targetConnection->origin = sourceConnection->origin;


### PR DESCRIPTION


## Pull Request

### Description

Cluster now holding metrics of how many blocks and synapse-sections they contain, which were also added to the output of the cluster get-endpoint.
<!-- A concise description of the content of the pull-request -->

### Related Issues

- #483
<!-- In context of which issues the changes of this pull request were created. -->

### How it was tested?

- manually test with the cli-client of the remaining cluster of a sdk-api-test
<!-- What parts and how they were tested -->
