### PR TITLE
fix: fixed build of the docs generated by CI

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -1243,12 +1243,6 @@ jobs:
         with:
           version: v0.8.0
       - 
-        name: Get artifact
-        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
-        with:
-          name: Hanami_debug_build_result
-          path: /tmp/Hanami_debug_build_result
-      - 
         name: Checkout repository
         run: |
           # use manually clone, because with the "actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332" action the name of the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@
 - some cases of invalid http-requests had returned an 200 reponse with empty body, which was fixed
 - changed token-key in helm-chart from configmap to secret
 - fixed memory-corruption in cluster-resize, because a pointer was used after free
+- fixed missing drawio-images in documentation when generating in CI
 
 ### Removed
 

--- a/Earthfile
+++ b/Earthfile
@@ -144,7 +144,7 @@ generate-docs:
     COPY +compile-code/hanami/hanami /tmp/
 
     RUN apt-get update && \
-        apt-get install -y openssl libuuid1 libcrypto++8 libsqlite3-0 libprotobuf23 libboost1.74
+        apt-get install -y openssl libuuid1 libcrypto++8 libsqlite3-0 libprotobuf23 libboost1.74 libgbm-dev libasound2
     RUN chmod +x /tmp/hanami
     RUN /tmp/hanami --generate_docu
 
@@ -168,6 +168,10 @@ generate-docs:
     RUN cp ./db.md docs/backend/
     RUN cp ./config.md docs/backend/
     RUN cp ./open_api_docu.json docs/frontend/
+
+    RUN useradd -m ubuntu
+    RUN chown -R ubuntu:ubuntu .
+    USER ubuntu
 
     RUN mkdocs build --clean
 


### PR DESCRIPTION


## Pull Request

### Description
When generating the webdocumentation within the CI, the drawio-images were missing. This should be fixed by this commit.
<!-- A concise description of the content of the pull-request -->

### Related Issues

- (no related issue)
<!-- In context of which issues the changes of this pull request were created. -->

### How it was tested?

- run build-step in CI and tested the resulting image
<!-- What parts and how they were tested -->
