### PR TITLE
fix: fix docs-build

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -156,7 +156,8 @@ generate-docs:
         pip3 install mkdocs \
                      mkdocs-material \
                      mkdocs-swagger-ui-tag \
-                     mkdocs-drawio-exporter && \
+                     # pin mkdocs-drawio-exporter because 0.10.x is broken
+                     mkdocs-drawio-exporter==0.9.1 && \
         curl -s https://api.github.com/repos/jgraph/drawio-desktop/releases/latest | grep browser_download_url | grep "amd64"  | grep "deb" | cut -d "\"" -f 4 | wget -i - && \ 
         apt -f -y install ./drawio-amd64-*.deb
 


### PR DESCRIPTION


## Pull Request

### Description
Pinned drawio-exporter pip-package, because
current version is broken.
<!-- A concise description of the content of the pull-request -->

### Related Issues

<!-- In context of which issues the changes of this pull request were created. -->

### How it was tested?

- local build of the documentation with the pinned version

<!-- What parts and how they were tested -->
