### PR TITLE
fix: fixed and update docker-build

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -1278,6 +1278,7 @@ jobs:
     name: "Upload files to share"
     needs: [ kubernetes_test ]
     runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/develop' || github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') }}
     env:
       FORCE_COLOR: 1
     steps:

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -41,7 +41,7 @@ jobs:
           # - you want to enable the Branch-Protection check on a *public* repository, or
           # - you are installing Scorecard on a *private* repository
           # To create the PAT, follow the steps in https://github.com/ossf/scorecard-action?tab=readme-ov-file#authentication-with-fine-grained-pat-optional.
-          # repo_token: ${{ secrets.SCORECARD_TOKEN }}
+          repo_token: ${{ secrets.SCORECARD_TOKEN }}
 
           # Public repositories:
           #   - Publish results to OpenSSF REST API for easy access by consumers

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 ### Changed
 
 - the resize-process was updated to avoid the search-loop for a new free section
+- updated ubuntu-version in docker-images to 24.04
 
 ### Fixed
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04 AS builder
+FROM ubuntu:24.04 AS builder
 
 ARG DEBIAN_FRONTEND=noninteractive
 
@@ -24,18 +24,19 @@ RUN apt-get update && \
 
 COPY . .
 
+RUN rm  -f src/libraries/hanami_messages/protobuffers/hanami_messages.proto3.pb.cc src/libraries/hanami_messages/protobuffers/hanami_messages.proto3.pb.h
 RUN cmake -DCMAKE_BUILD_TYPE=Release .
 RUN make -j8
 RUN mkdir -p /app/ && \
     find src -type f -executable -exec cp {} /app/ \;
 
 
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && \
-    apt-get install -y openssl libuuid1 libcrypto++8 libsqlite3-0 libprotobuf23 libboost1.74 && \
+    apt-get install -y openssl libuuid1 libcrypto++8 libsqlite3-0 libboost1.74 libprotobuf32t64 && \
     apt-get clean autoclean &&\
     apt-get autoremove --yes
 

--- a/docs/repo/dependencies.md
+++ b/docs/repo/dependencies.md
@@ -28,14 +28,15 @@
 
 ### Runtime
 
-| apt-package   | Purpose                                                                               |
-| ------------- | ------------------------------------------------------------------------------------- |
-| openssl       | ssl-library for TCS-encryption of network-connections                                 |
-| libuuid1      | Generate UUID's within the code                                                       |
-| libcrypto++8  | HMAC, SHA256 and other crypto related operations                                      |
-| libsqlite3-0  | Library to interact with the SQLite3 databases                                        |
-| libprotobuf23 | Runtime-library for protobuffers                                                      |
-| libboost1.74  | Provides the Beast-library of Boost, which is used for the REST-API within OpenHanami |
+| apt-package      | Purpose                                                                               |
+| ---------------- | ------------------------------------------------------------------------------------- |
+| openssl          | ssl-library for TCS-encryption of network-connections                                 |
+| libuuid1         | Generate UUID's within the code                                                       |
+| libcrypto++8     | HMAC, SHA256 and other crypto related operations                                      |
+| libsqlite3-0     | Library to interact with the SQLite3 databases                                        |
+| libprotobuf23    | Runtime-library for protobuffers (for Ubuntu 22.04)                                   |
+| libprotobuf32t64 | Runtime-library for protobuffers (for Ubuntu 24.04)                                   |
+| libboost1.74     | Provides the Beast-library of Boost, which is used for the REST-API within OpenHanami |
 
 ### Supported compiler
 


### PR DESCRIPTION

## Pull Request

### Description

The protobuf-package was not found anymore in the
arm-build, even it was still ubuntu 22.04 used.
By this change I updated the ubuntu-version in the docker-images to ubuntu 24.04 and updated the
libprotobuf-package to the new one.

<!-- A concise description of the content of the pull-request -->

### Related Issues

- (no related issue)
<!-- In context of which issues the changes of this pull request were created. -->

### How it was tested?

- complete ci-pipeline
<!-- What parts and how they were tested -->
