### PR TITLE
fix(#501): fix broken output-processing in bigger examples

### DIFF
--- a/src/hanami/src/core/cluster/objects.h
+++ b/src/hanami/src/core/cluster/objects.h
@@ -264,7 +264,7 @@ struct OutputInterface {
     std::string name = "";
     uint32_t targetHexagonId = UNINIT_STATE_32;
     std::vector<OutputNeuron> outputNeurons;
-    std::vector<OutputWeightBlock> weights;
+    std::vector<OutputWeightBlock> weightBlocks;
     std::vector<AxonBlock> targetAxonBlocks;
     std::vector<float> ioBuffer;
     OutputType type = PLAIN_OUTPUT;

--- a/src/hanami/src/core/io/checkpoint/io_interface.cpp
+++ b/src/hanami/src/core/io/checkpoint/io_interface.cpp
@@ -250,7 +250,7 @@ IO_Interface::getHexagonSize(const Hexagon& hexagon) const
 
     if (hexagon.outputInterface != nullptr) {
         size += sizeof(OutputEntry);
-        size += hexagon.outputInterface->weights.size() * sizeof(OutputWeightBlock);
+        size += hexagon.outputInterface->weightBlocks.size() * sizeof(OutputWeightBlock);
         size += hexagon.outputInterface->outputNeurons.size() * sizeof(OutputNeuron);
     }
 
@@ -337,13 +337,13 @@ IO_Interface::serializeHexagon(const Hexagon& hexagon, Hanami::ErrorContainer& e
         outputEntry.type = hexagon.outputInterface->type;
         outputEntry.numberOfOutputs = hexagon.outputInterface->ioBuffer.size();
         outputEntry.targetHexagonId = hexagon.header.hexagonId;
-        outputEntry.numberOfWeightBlocks = hexagon.outputInterface->weights.size();
+        outputEntry.numberOfWeightBlocks = hexagon.outputInterface->weightBlocks.size();
         if (addObjectToLocalBuffer(&outputEntry, error) == false) {
             return ERROR;
         }
 
         // write weight-blocks to buffer
-        for (const OutputWeightBlock& weightBlock : hexagon.outputInterface->weights) {
+        for (const OutputWeightBlock& weightBlock : hexagon.outputInterface->weightBlocks) {
             if (addObjectToLocalBuffer(&weightBlock, error) == false) {
                 return ERROR;
             }
@@ -511,10 +511,10 @@ IO_Interface::deserializeHexagon(Hexagon& hexagon,
         outputIf.type = outputEntry.type;
         outputIf.targetHexagonId = hexagon.header.hexagonId;
         outputIf.initBuffer(outputEntry.numberOfOutputs, 1);
-        outputIf.weights.resize(outputEntry.numberOfWeightBlocks);
+        outputIf.weightBlocks.resize(outputEntry.numberOfWeightBlocks);
 
         // read weight-blocks
-        for (OutputWeightBlock& weightBlock : outputIf.weights) {
+        for (OutputWeightBlock& weightBlock : outputIf.weightBlocks) {
             ret = getObjectFromLocalBuffer(positionPtr, &weightBlock, error);
             if (ret != OK) {
                 return ret;
@@ -675,7 +675,7 @@ IO_Interface::createHexagonEntry(const Hexagon& hexagon)
         hexagonEntry.outputsInterfacesPos = posCounter;
         hexagonEntry.numberOfOutputBytes
             = sizeof(OutputEntry)
-              + (hexagon.outputInterface->weights.size() * sizeof(OutputWeightBlock))
+              + (hexagon.outputInterface->weightBlocks.size() * sizeof(OutputWeightBlock))
               + (hexagon.outputInterface->outputNeurons.size() * sizeof(OutputNeuron));
     }
 

--- a/src/hanami/src/core/processing/axon_handling.h
+++ b/src/hanami/src/core/processing/axon_handling.h
@@ -63,11 +63,11 @@ _transferAxonBlockToOutput(Hexagon* hexagon)
         outputInterface->targetAxonBlocks.resize(hexagon->axonBlocks.size());
         const int64_t totalWeightBlocks
             = hexagon->axonBlocks.size() * outputInterface->outputNeurons.size();
-        const int64_t diff = totalWeightBlocks - outputInterface->weights.size();
+        const int64_t diff = totalWeightBlocks - outputInterface->weightBlocks.size();
 
         // update weight-blocks
         if (diff > 0) {
-            outputInterface->weights.resize(totalWeightBlocks, OutputWeightBlock());
+            outputInterface->weightBlocks.resize(totalWeightBlocks, OutputWeightBlock());
         }
     }
 

--- a/src/hanami/src/core/processing/cpu/output_backpropagation.h
+++ b/src/hanami/src/core/processing/cpu/output_backpropagation.h
@@ -50,28 +50,28 @@ backpropagateOutput(OutputInterface* outputInterface)
     Axon* axon = nullptr;
     AxonBlock* axonBlock = nullptr;
     OutputNeuron* out = nullptr;
-    OutputWeightBlock* weightBlocks = nullptr;
+    OutputWeightBlock* weightBlockSection = nullptr;
     OutputWeightBlock* wBlock = nullptr;
 
-    if (outputInterface->weights.size() == 0) {
+    if (outputInterface->weightBlocks.size() == 0) {
         return true;
     }
 
-    assert(outputInterface->weights.size() % outputInterface->outputNeurons.size() == 0);
-    const uint64_t dim = outputInterface->weights.size() / outputInterface->outputNeurons.size();
+    assert(outputInterface->weightBlocks.size() % outputInterface->outputNeurons.size() == 0);
+    const uint64_t dim
+        = outputInterface->weightBlocks.size() / outputInterface->outputNeurons.size();
+    assert(dim == outputInterface->targetAxonBlocks.size());
 
     for (outPos = 0; outPos < outputInterface->outputNeurons.size(); ++outPos) {
         out = &outputInterface->outputNeurons[outPos];
-        weightBlocks = &outputInterface->weights[outPos * dim];
+        weightBlockSection = &outputInterface->weightBlocks[outPos * dim];
 
         delta = out->outputVal - out->exprectedVal;
         update = delta * out->outputVal * (1 - out->outputVal);
 
-        for (wb = 0; wb < outputInterface->weights.size();
-             wb += outputInterface->outputNeurons.size())
-        {
-            wBlock = &weightBlocks[wb];
+        for (wb = 0; wb < dim; ++wb) {
             axonBlock = &outputInterface->targetAxonBlocks[wb];
+            wBlock = &weightBlockSection[wb];
 
             for (w = 0; w < NEURONS_PER_BLOCK; ++w) {
                 axon = &axonBlock->axons[w];

--- a/src/hanami/src/core/processing/cpu/output_processing.h
+++ b/src/hanami/src/core/processing/cpu/output_processing.h
@@ -67,27 +67,27 @@ processNeuronsOfOutputHexagon(Hexagon* hexagon, uint32_t randomSeed)
     uint32_t w = 0;
 
     OutputNeuron* out = nullptr;
-    OutputWeightBlock* weightBlocks = nullptr;
+    OutputWeightBlock* weightBlockSection = nullptr;
     OutputWeightBlock* wBlock = nullptr;
     OutputInterface* outputInterface = hexagon->outputInterface;
 
-    if (outputInterface->weights.size() == 0) {
+    if (outputInterface->weightBlocks.size() == 0) {
         return;
     }
 
-    assert(outputInterface->weights.size() % outputInterface->outputNeurons.size() == 0);
-    const uint64_t dim = outputInterface->weights.size() / outputInterface->outputNeurons.size();
+    assert(outputInterface->weightBlocks.size() % outputInterface->outputNeurons.size() == 0);
+    const uint64_t dim
+        = outputInterface->weightBlocks.size() / outputInterface->outputNeurons.size();
+    assert(dim == outputInterface->targetAxonBlocks.size());
 
     for (outPos = 0; outPos < outputInterface->outputNeurons.size(); ++outPos) {
         out = &outputInterface->outputNeurons[outPos];
-        weightBlocks = &outputInterface->weights[outPos * dim];
+        weightBlockSection = &outputInterface->weightBlocks[outPos * dim];
         weightSum = 0.0f;
 
-        for (wb = 0; wb < outputInterface->weights.size();
-             wb += outputInterface->outputNeurons.size())
-        {
+        for (wb = 0; wb < dim; ++wb) {
             axonBlock = &outputInterface->targetAxonBlocks[wb];
-            wBlock = &weightBlocks[wb];
+            wBlock = &weightBlockSection[wb];
 
             for (w = 0; w < NEURONS_PER_BLOCK; ++w) {
                 axon = &axonBlock->axons[w];


### PR DESCRIPTION


## Pull Request

### Description

In case the output is bigger than one block, it crashed because of a stupid mistake of myself in reading the blocks. This was fixed now.
<!-- A concise description of the content of the pull-request -->

### Related Issues

- #501 
<!-- In context of which issues the changes of this pull request were created. -->

### How it was tested?

other test, which produced more output
<!-- What parts and how they were tested -->
