### PR TITLE
feat(#469): allow negative input-values

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -3,7 +3,7 @@
 # run clang-format on all c-file of the commit
 for FILE in $(git diff --cached --name-only | grep -E '.*\.(c$|cpp$|h$|hpp$)')
 do
-    clang-format-18 -style=file:.clang-format -i $FILE
+    clang-format-15 -style=file:.clang-format -i $FILE
     git add $FILE | true
 done
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - updated section-processing for better input-handling especially for binary input data
 - replaced the old split-process for sections to avoid loosing half of the trained section in the process
 - dynamically link sections to connections in order to make memory usage more efficient
+- net input can now also handle negative values as input
 
 #### Template-Breaking
 

--- a/README.md
+++ b/README.md
@@ -103,8 +103,8 @@ and multi-tenancy.
 
 -   **No normalization of input**
 
-    The input of the network is not restricted to range of 0.0 - 1.0 . Every value, as long it is a
-    positive value, can be inserted. Also if there is a single broken value in the input-data, which
+    The input of the network is not restricted to range of 0.0 - 1.0 . Every value can be inserted, 
+    even negative values. Also if there is a single broken value in the input-data, which
     is million times higher, than the rest of the input-values, it has nearly no effect on the rest
     of the already trained data. Thanks to the reduction-process, all synapses, which are only the
     result of this single input, are removed again from the network.

--- a/docs/index.md
+++ b/docs/index.md
@@ -34,8 +34,8 @@ and multi-tenancy.
 
 -   **No normalization of input**
 
-    The input of the network is not restricted to range of 0.0 - 1.0 . Every value, as long it is a
-    positive value, can be inserted. Also if there is a single broken value in the input-data, which
+    The input of the network is not restricted to range of 0.0 - 1.0 . Every value can be inserted, 
+    even negative values. Also if there is a single broken value in the input-data, which
     is million times higher, than the rest of the input-values, it has nearly no effect on the rest
     of the already trained data.
 

--- a/src/hanami/src/api/http/dataset/csv/finalize_csv_dataset_v1_0.cpp
+++ b/src/hanami/src/api/http/dataset/csv/finalize_csv_dataset_v1_0.cpp
@@ -32,6 +32,8 @@
 #include <hanami_crypto/common.h>
 #include <hanami_root.h>
 
+#include <regex>
+
 FinalizeCsvDataSetV1M0::FinalizeCsvDataSetV1M0()
     : Blossom(
         "Finalize uploaded dataset by checking completeness of the "

--- a/src/hanami/src/api/http/dataset/csv/finalize_csv_dataset_v1_0.h
+++ b/src/hanami/src/api/http/dataset/csv/finalize_csv_dataset_v1_0.h
@@ -26,8 +26,6 @@
 #include <api/endpoint_processing/blossom.h>
 #include <hanami_common/buffer/data_buffer.h>
 
-#include <regex>
-
 class FinalizeCsvDataSetV1M0 : public Blossom
 {
    public:

--- a/src/hanami/src/api/websocket/cluster_io.cpp
+++ b/src/hanami/src/api/websocket/cluster_io.cpp
@@ -204,9 +204,23 @@ recvClusterInputMessage(Cluster* cluster, const void* data, const uint64_t dataS
 
         // apply values
         AxonBlock* axonBlock = nullptr;
-        for (uint64_t i = 0; i < msg.numberofvalues(); i++) {
-            axonBlock = &inputInterface->inputAxons[i / NEURONS_PER_BLOCK];
-            axonBlock->axons[i % NEURONS_PER_BLOCK].potential = msg.values(i);
+        Axon* axon = nullptr;
+        uint64_t bufferPos = 0;
+        uint64_t blockId = 0;
+        uint16_t axonId = 0;
+        float val = 0.0f;
+
+        for (uint64_t i = 0; i < msg.numberofvalues(); ++i) {
+            bufferPos = i * 2;
+            blockId = bufferPos / NEURONS_PER_BLOCK;
+            axonId = bufferPos % NEURONS_PER_BLOCK;
+            val = msg.values(i);
+
+            axonBlock = &inputInterface->inputAxons[blockId];
+            axonBlock->axons[axonId].potential = 0.0f;
+            axonBlock->axons[axonId + 1].potential = 0.0f;
+            axon = &axonBlock->axons[axonId + (val >= 0.0f)];
+            axon->potential = abs(val);
         }
     }
     else if (msg.targetbuffertype() == TargetBufferType::EXPECTED_BUFFER_TYPE) {

--- a/src/hanami/src/api/websocket/file_upload.h
+++ b/src/hanami/src/api/websocket/file_upload.h
@@ -25,6 +25,8 @@
 
 #include <hanami_common/structs.h>
 
+#include "hanami_common/upload_file_handle.h"
+
 class HttpWebsocketThread;
 
 bool recvFileUploadPackage(Hanami::UploadFileHandle* fileHandle,

--- a/src/hanami/src/core/cluster/objects.h
+++ b/src/hanami/src/core/cluster/objects.h
@@ -256,7 +256,7 @@ struct OutputNeuron {
     float exprectedVal = 0.0f;
     uint8_t padding[8];
 };
-// static_assert(sizeof(OutputNeuron) == 128);
+static_assert(sizeof(OutputNeuron) == 16);
 
 //==================================================================================================
 
@@ -300,9 +300,12 @@ struct InputInterface {
         if (ioBuffer.size() != expectedSize) {
             ioBuffer.resize(expectedSize);
         }
-        expectedSize += (timeLength - 1);
-        expectedSize /= NEURONS_PER_BLOCK;
-        expectedSize++;
+
+        expectedSize += (timeLength - 1);  // respect time-length of the input
+        expectedSize *= 2;  // double length to also hold a negative value for the inputs
+        expectedSize /= NEURONS_PER_BLOCK;  // convert entries to blocks
+        expectedSize++;  // becaus of the line above to fix rounding-error add a new block
+
         if (inputAxons.size() < expectedSize) {
             const uint64_t oldSize = 0;
             inputAxons.resize(expectedSize);

--- a/src/hanami/src/core/cluster/states/request_state.cpp
+++ b/src/hanami/src/core/cluster/states/request_state.cpp
@@ -48,10 +48,15 @@ Request_State::processEvent()
     Task* actualTask = m_cluster->getCurrentTask();
     RequestInfo* info = &std::get<RequestInfo>(actualTask->info);
 
+    AxonBlock* axonBlock = nullptr;
+    Axon* axon = nullptr;
+    uint64_t blockId = 0;
+    uint16_t axonId = 0;
+
     for (auto& [hexagonName, input] : info->inputs) {
         uint64_t counter = 0;
         InputInterface* inputInterface = &m_cluster->inputInterfaces[hexagonName];
-        AxonBlock* axonBlock = nullptr;
+
         for (uint64_t t = 0; t < info->timeLength; ++t) {
             if (getDataFromDataSet(inputInterface->ioBuffer, input, info->currentCycle + t, error)
                 != OK)
@@ -59,9 +64,14 @@ Request_State::processEvent()
                 return false;
             }
             for (const float val : inputInterface->ioBuffer) {
-                axonBlock = &inputInterface->inputAxons[counter / NEURONS_PER_BLOCK];
-                axonBlock->axons[counter % NEURONS_PER_BLOCK].potential = val;
-                counter++;
+                blockId = counter / NEURONS_PER_BLOCK;
+                axonId = counter % NEURONS_PER_BLOCK;
+                axonBlock = &inputInterface->inputAxons[blockId];
+                axonBlock->axons[axonId].potential = 0.0f;
+                axonBlock->axons[axonId + 1].potential = 0.0f;
+                axon = &axonBlock->axons[axonId + (val >= 0.0f)];
+                axon->potential = abs(val);
+                counter += 2;
             }
         }
     }

--- a/src/hanami/src/core/cluster/states/train_forward_state.cpp
+++ b/src/hanami/src/core/cluster/states/train_forward_state.cpp
@@ -49,11 +49,15 @@ TrainForward_State::processEvent()
     Task* actualTask = m_cluster->getCurrentTask();
     TrainInfo* info = &std::get<TrainInfo>(actualTask->info);
 
+    AxonBlock* axonBlock = nullptr;
+    Axon* axon = nullptr;
+    uint64_t blockId = 0;
+    uint16_t axonId = 0;
+
     for (auto& [hexagonName, input] : info->inputs) {
         uint64_t counter = 0;
         InputInterface* inputInterface = &m_cluster->inputInterfaces[hexagonName];
-        AxonBlock* axonBlock = nullptr;
-        Axon* axon = nullptr;
+
         for (uint64_t t = 0; t < info->timeLength; ++t) {
             if (getDataFromDataSet(inputInterface->ioBuffer, input, info->currentCycle + t, error)
                 != OK)
@@ -61,12 +65,14 @@ TrainForward_State::processEvent()
                 return false;
             }
             for (const float val : inputInterface->ioBuffer) {
-                const uint64_t blockId = counter / NEURONS_PER_BLOCK;
-                const uint16_t axonId = counter % NEURONS_PER_BLOCK;
+                blockId = counter / NEURONS_PER_BLOCK;
+                axonId = counter % NEURONS_PER_BLOCK;
                 axonBlock = &inputInterface->inputAxons[blockId];
-                axon = &axonBlock->axons[axonId];
-                axon->potential = val;
-                counter++;
+                axonBlock->axons[axonId].potential = 0.0f;
+                axonBlock->axons[axonId + 1].potential = 0.0f;
+                axon = &axonBlock->axons[axonId + (val >= 0.0f)];
+                axon->potential = abs(val);
+                counter += 2;
             }
         }
     }

--- a/src/hanami/src/core/io/data_set/dataset_file_io.h
+++ b/src/hanami/src/core/io/data_set/dataset_file_io.h
@@ -32,7 +32,6 @@
 
 #include <cstring>
 #include <string>
-#include <type_traits>
 #include <vector>
 
 enum DataSetType : uint8_t {


### PR DESCRIPTION

## Pull Request

### Description

The input-values can now be positive and negative. This was done by extanding the input to have 2 nodes per input-value, one for the positive and one for the negative. This double the number of input-nodes, but nodes, which are 0 have no really impact on the
performance of the network.

<!-- A concise description of the content of the pull-request -->

### Related Issues

- #469 
<!-- In context of which issues the changes of this pull request were created. -->

### How it was tested?

- modified version of the measure_tests, where some inputs were changed to negative values
<!-- What parts and how they were tested -->
