### PR TITLE
fix: fix invalid dataset-download-request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 
 - wrong return-code in one error-case of the create-train-task endpoint was fixed
 - fixed offset in the output of the timeseries training from datasets
+- download of dataset with a too big number of requested rows and offset was fixed to handle this cases correctly
 
 ### Removed
 

--- a/src/hanami/src/api/http/dataset/download_dataset_content_v1_0.cpp
+++ b/src/hanami/src/api/http/dataset/download_dataset_content_v1_0.cpp
@@ -98,8 +98,24 @@ DownloadDatasetContentV1M0::runTask(BlossomIO& blossomIO,
     const json range = datasetFileHandle.description[columnName];
     datasetFileHandle.readSelector.columnStart = range["column_start"];
     datasetFileHandle.readSelector.columnEnd = range["column_end"];
+
+    // check requested offset
+    if (rowOffset >= datasetFileHandle.header.numberOfRows) {
+        status.statusCode = INVALID_INPUT;
+        status.errorMessage
+            = "Requested row_offset is too big for the dataset with UUID '" + datasetUuid + "'";
+        error.addMessage(status.errorMessage);
+        return false;
+    }
     datasetFileHandle.readSelector.startRow = rowOffset;
-    datasetFileHandle.readSelector.endRow = rowOffset + numberOfRows;
+
+    // check and set number of requested rows
+    if (rowOffset + numberOfRows > datasetFileHandle.header.numberOfRows) {
+        datasetFileHandle.readSelector.endRow = datasetFileHandle.header.numberOfRows - rowOffset;
+    }
+    else {
+        datasetFileHandle.readSelector.endRow = rowOffset + numberOfRows;
+    }
 
     // init buffer for output
     const uint64_t numberOfColumns


### PR DESCRIPTION

## Pull Request

### Description

When downloading a dataset with a too high request amount of rows, the download failed with the wrong error-message. This was fixed by an additonal check, which cuts the number if too big and downloads only the available values, even when the requested amount of rows was much bigger. A too big row-offset is now checked by an additional if-condition to give a
correct error-message in this case.

<!-- A concise description of the content of the pull-request -->

### Related Issues

- (no related issue)
<!-- In context of which issues the changes of this pull request were created. -->

### How it was tested?

- modified version of the measure_tests in context of issue #454

<!-- What parts and how they were tested -->
