### PR TITLE
feat(#567): add time-length-value again

### DIFF
--- a/src/hanami/src/api/http_endpoints/cluster/task/create_request_task_v1_0.rs
+++ b/src/hanami/src/api/http_endpoints/cluster/task/create_request_task_v1_0.rs
@@ -125,7 +125,7 @@ pub async fn create_request_task(body: Json<TaskCreateRequestReq>, cluster_uuid:
         inputs: HashMap::new(),
         results: result_file_handle,
         number_of_cycles: 0,
-        time_length: 1,
+        time_length: body.time_length,
     };
 
     let mut number_of_cycles =  u64::MAX;
@@ -157,9 +157,13 @@ pub async fn create_request_task(body: Json<TaskCreateRequestReq>, cluster_uuid:
         };
     }
 
+    if number_of_cycles < body.time_length {
+        let msg = format!("Time-length {} is bigger than at least of of the seleced datasets.", body.time_length);
+        return Err(ErrorResponse::BadRequest(msg));
+    }
+    number_of_cycles -= body.time_length - 1;
+
     info.number_of_cycles = number_of_cycles;
-
-
 
     // add new task to database
     match task_table::add_new_task(

--- a/src/hanami/src/api/http_endpoints/cluster/task/create_train_task_v1_0.rs
+++ b/src/hanami/src/api/http_endpoints/cluster/task/create_train_task_v1_0.rs
@@ -70,8 +70,8 @@ pub async fn create_train_task(body: Json<TaskCreateTrainReq>, cluster_uuid: Pat
         inputs: HashMap::new(),
         outputs: HashMap::new(),
         number_of_cycles: 0,
-        number_of_epochs: body.number_of_epochs.clone(),
-        time_length: 1,
+        number_of_epochs: body.number_of_epochs,
+        time_length: body.time_length,
     };
 
     let mut number_of_cycles =  u64::MAX;
@@ -125,6 +125,13 @@ pub async fn create_train_task(body: Json<TaskCreateTrainReq>, cluster_uuid: Pat
             }
         };
     }
+
+    // handle the time-lenght-value
+    if number_of_cycles < body.time_length {
+        let msg = format!("Time-length {} is bigger than at least of of the seleced datasets.", body.time_length);
+        return Err(ErrorResponse::BadRequest(msg));
+    }
+    number_of_cycles -= body.time_length - 1;
 
     info.number_of_cycles = number_of_cycles;
 

--- a/src/hanami/src/api/http_endpoints/cluster/task/task_structs.rs
+++ b/src/hanami/src/api/http_endpoints/cluster/task/task_structs.rs
@@ -110,6 +110,7 @@ pub struct TaskDatasetResultLink {
 pub struct TaskCreateTrainReq {
     pub name: String,
     pub number_of_epochs: u64,
+    pub time_length: u64,
     pub inputs: Vec<TaskDatasetLink>,
     pub outputs: Vec<TaskDatasetLink>,
 }
@@ -117,6 +118,7 @@ pub struct TaskCreateTrainReq {
 #[derive(Serialize, Deserialize, Debug, Clone, JsonSchema, ApiComponent)]
 pub struct TaskCreateRequestReq {
     pub name: String,
+    pub time_length: u64,
     pub inputs: Vec<TaskDatasetLink>,
     pub results: Vec<TaskDatasetResultLink>,
 }

--- a/src/hanami/src/core/cluster.rs
+++ b/src/hanami/src/core/cluster.rs
@@ -40,14 +40,46 @@ pub struct ClusterLinkHanle {
     pub cluster_link: UniquePtr<ffi::ClusterLink>, 
 }
 
-fn get_values(
+fn get_input_from_dataset(
     hexagon_name: &String, 
     file_handle: &mut DataSetFileReadHandleV1_0, 
-    cycle_count: &u64, 
-    cluster_link: &mut UniquePtr<ffi::ClusterLink>, 
-    is_expected: bool) -> Result<(), String> 
+    cycle_count: u64, 
+    time_length: u64, 
+    cluster_link: &mut UniquePtr<ffi::ClusterLink>) -> Result<(), String> 
 {
-    let (input_ptr, size_input) = match file_handle.get_data_from_file(cycle_count) {
+    let mut pos_counter: u64 = 0;
+
+    for time_point in 0..time_length {
+        let (input_ptr, size_input) = match file_handle.get_data_from_file(&(cycle_count + time_point)) {
+            Ok((input_ptr, size_input)) => (input_ptr, size_input),
+            Err(msg) => {
+                return Err(msg);
+            }
+        };
+
+        // tigger action in c++ code
+        cxx::let_cxx_string!(cxx_name = hexagon_name); 
+        unsafe {
+            if cluster_link.pin_mut().fillInput(&cxx_name, input_ptr, size_input as u64, pos_counter, time_length) == false {
+                let msg: String = format!("Hexagon with name '{hexagon_name}' not found in cluster.");
+                return Err(msg);
+            }
+        }
+
+        pos_counter += size_input as u64 * 2;
+    }
+
+    Ok(())
+} 
+
+fn get_expected_from_dataset(
+    hexagon_name: &String, 
+    file_handle: &mut DataSetFileReadHandleV1_0, 
+    cycle_count: u64, 
+    time_length: u64, 
+    cluster_link: &mut UniquePtr<ffi::ClusterLink>) -> Result<(), String> 
+{
+    let (input_ptr, size_input) = match file_handle.get_data_from_file(&(cycle_count + time_length - 1)) {
         Ok((input_ptr, size_input)) => (input_ptr, size_input),
         Err(msg) => {
             return Err(msg);
@@ -56,26 +88,17 @@ fn get_values(
 
     // tigger action in c++ code
     cxx::let_cxx_string!(cxx_name = hexagon_name); 
-    if is_expected == false {
-        unsafe {
-            if cluster_link.pin_mut().fillInput(&cxx_name, input_ptr, size_input as u64) == false {
-                let msg: String = format!("Hexagon with name '{hexagon_name}' not found in cluster.");
-                return Err(msg);
-            }
-        }
-    } else {
-        unsafe {
-            if cluster_link.pin_mut().fillExpected(&cxx_name, input_ptr, size_input as u64) == false {
-                let msg = format!("Hexagon with name '{hexagon_name}' not found in cluster.");
-                return Err(msg);
-            }
+    unsafe {
+        if cluster_link.pin_mut().fillExpected(&cxx_name, input_ptr, size_input as u64) == false {
+            let msg = format!("Hexagon with name '{hexagon_name}' not found in cluster.");
+            return Err(msg);
         }
     }
 
     Ok(())
-}
+} 
 
-fn write_values(
+fn write_output_into_dataset(
     file_handle: &mut DataSetFileWriteHandleV1_0, 
     cluster_link: &mut UniquePtr<ffi::ClusterLink>) -> Result<(), String> 
 {
@@ -128,7 +151,7 @@ fn handle_train_task(task_uuid: &Uuid, task_info: &mut TrainInfo, link_handle: &
 
             // push input-values form dataset into the backend
             for (hexagon_name, file_handle) in &mut task_info.inputs {  
-                match get_values(hexagon_name, file_handle, &cycle_count, &mut link.cluster_link, false) {
+                match get_input_from_dataset(hexagon_name, file_handle, cycle_count, task_info.time_length, &mut link.cluster_link) {
                     Ok(()) => {},
                     Err(e) => {
                         let _ = task_table::set_error_state(&task_uuid, &e);
@@ -139,7 +162,7 @@ fn handle_train_task(task_uuid: &Uuid, task_info: &mut TrainInfo, link_handle: &
 
             // push output-values form dataset into the backend
             for (hexagon_name, file_handle) in &mut task_info.outputs {  
-                match get_values(hexagon_name, file_handle, &cycle_count, &mut link.cluster_link, true) {
+                match get_expected_from_dataset(hexagon_name, file_handle, cycle_count, task_info.time_length, &mut link.cluster_link) {
                     Ok(()) => {},
                     Err(e) => {
                         let _ = task_table::set_error_state(&task_uuid, &e);
@@ -167,46 +190,44 @@ fn handle_request_task(task_uuid: &Uuid, task_info: &mut RequestInfo, link_handl
     let mut prev_timestamp = Instant::now();
     let _ = task_table::update_task_state(&task_uuid, &TaskState::Active);
 
-    for epoch_count in 0..1 {
-        for cycle_count in 0..task_info.number_of_cycles {
-            // update current state in database at least after 1 second
-            let now = Instant::now();
-            if now.duration_since(prev_timestamp) >= Duration::from_secs(1) {
-                prev_timestamp = now;
-                let _ = task_table::update_task_progress(task_uuid, &(epoch_count as i64), &(cycle_count as i64));
+    for cycle_count in 0..task_info.number_of_cycles {
+        // update current state in database at least after 1 second
+        let now = Instant::now();
+        if now.duration_since(prev_timestamp) >= Duration::from_secs(1) {
+            prev_timestamp = now;
+            let _ = task_table::update_task_progress(task_uuid, &0 , &(cycle_count as i64));
 
-                // check if task was aborted
-                if task_table::is_aborted(&task_uuid) {
-                    return;
-                }
+            // check if task was aborted
+            if task_table::is_aborted(&task_uuid) {
+                return;
             }
+        }
 
-            let mut link = link_handle.lock().unwrap();
+        let mut link = link_handle.lock().unwrap();
 
-            // push input-values form dataset into the backend
-            for (hexagon_name, file_handle) in &mut task_info.inputs {  
-                match get_values(hexagon_name, file_handle, &cycle_count, &mut link.cluster_link, false) {
-                    Ok(()) => {},
-                    Err(e) => {
-                        let _ = task_table::set_error_state(&task_uuid, &e);
-                        return;
-                    }
-                }
-            }
-
-            link.cluster_link.pin_mut().doRequest();
-
-            // get output-values form backend and write them into the dataset
-            match write_values(&mut task_info.results, &mut link.cluster_link) {
+        // push input-values form dataset into the backend
+        for (hexagon_name, file_handle) in &mut task_info.inputs {  
+            match get_input_from_dataset(hexagon_name, file_handle, cycle_count, task_info.time_length, &mut link.cluster_link) {
                 Ok(()) => {},
                 Err(e) => {
                     let _ = task_table::set_error_state(&task_uuid, &e);
                     return;
                 }
             }
-
-            drop(link);
         }
+
+        link.cluster_link.pin_mut().doRequest();
+
+        // get output-values form backend and write them into the dataset
+        match write_output_into_dataset(&mut task_info.results, &mut link.cluster_link) {
+            Ok(()) => {},
+            Err(e) => {
+                let _ = task_table::set_error_state(&task_uuid, &e);
+                return;
+            }
+        }
+
+        drop(link);
     }
 
     let _ = task_table::update_task_state(&task_uuid, &TaskState::Finished);
@@ -295,14 +316,10 @@ impl Cluster {
         let handle = thread::spawn(move || {
             debug!("Started cluster-thread");
             while running_clone.load(Ordering::Relaxed) {
-                // println!("Looping forever");
-
                 // get task fromt he task-queue and prcess the task, otherwise sleep until the next check
                 let mut queue_handle = queue_clone.lock().unwrap();
                 if let Some(task) = queue_handle.get() {
                     drop(queue_handle);
-                    //println!("Popped from front: {:?}", task);
-
                     handle_task(task, &link_handle_clone);
                 } else {
                     drop(queue_handle);
@@ -339,9 +356,10 @@ impl Cluster {
         // push input-values form dataset into the backend
         for (hexagon_name, data) in inputs {  
             let data_ptr = data.as_ptr();
+
             cxx::let_cxx_string!(cxx_name = hexagon_name); 
             unsafe {
-                if link.cluster_link.pin_mut().fillInput(&cxx_name, data_ptr, data.len() as u64) == false {
+                if link.cluster_link.pin_mut().fillInput(&cxx_name, data_ptr, data.len() as u64, 0, 1) == false {
                     let msg = format!("Hexagon with name '{hexagon_name}' not found in cluster.");
                     return Err(msg);
                 }
@@ -377,7 +395,7 @@ impl Cluster {
             let data_ptr = data.as_ptr();
             cxx::let_cxx_string!(cxx_name = hexagon_name); 
             unsafe {
-                if link.cluster_link.pin_mut().fillInput(&cxx_name, data_ptr, data.len() as u64) == false {
+                if link.cluster_link.pin_mut().fillInput(&cxx_name, data_ptr, data.len() as u64, 0, 1) == false {
                     let msg = format!("Hexagon with name '{hexagon_name}' not found in cluster.");
                     return Err(msg);
                 }

--- a/src/hanami/src/core/tasks.rs
+++ b/src/hanami/src/core/tasks.rs
@@ -18,8 +18,6 @@ use uuid::Uuid;
 
 use hanami_dataset::dataset_io::{DataSetFileReadHandleV1_0, DataSetFileWriteHandleV1_0};
 
-use crate::api::http_endpoints::cluster::task::task_structs::TaskType;
-
 #[derive(Debug)]
 pub struct TrainInfo {
     pub inputs: HashMap<String, DataSetFileReadHandleV1_0>,

--- a/src/hanami/src/database/task_table.rs
+++ b/src/hanami/src/database/task_table.rs
@@ -74,7 +74,6 @@ pub struct TaskEntry {
 
 pub fn init_task_table() -> Result<(), Box<dyn Error>> {
     let mut conn = db_handle::DB_CONN.lock().unwrap();
-    error!("poi1");
     conn.batch_execute("CREATE TABLE IF NOT EXISTS tasks (
         uuid VARCHAR(40) PRIMARY KEY,
         name VARCHAR(256),
@@ -96,7 +95,6 @@ pub fn init_task_table() -> Result<(), Box<dyn Error>> {
         created_by VARCHAR(256)
     );")?;
 
-    error!("poi1");
     Ok(())
 }
 

--- a/src/libs/cpp/hanami_core/CMakeLists.txt
+++ b/src/libs/cpp/hanami_core/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.16)
 project(hanami_core_cpp VERSION 0.1 LANGUAGES C CXX)
 
+# set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -gdwarf-4  -fsanitize=address -fno-omit-frame-pointer")
+# set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -gdwarf-4  -fsanitize=address -fno-omit-frame-pointer")
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/src/libs/cpp/hanami_core/cluster_link.h
+++ b/src/libs/cpp/hanami_core/cluster_link.h
@@ -40,7 +40,9 @@ class ClusterLink
 
     bool fillInput(const std::string& hexagonName,
                    const float* input,
-                   const uint64_t numberOfInputs);
+                   const uint64_t numberOfInputs,
+                   const uint64_t bufferOffset,
+                   const uint64_t totalTimeLength);
     bool fillExpected(const std::string& hexagonName,
                       const float* output,
                       const uint64_t numberOfOutputs);

--- a/src/libs/cpp/hanami_core/src/cluster/cluster_link.cpp
+++ b/src/libs/cpp/hanami_core/src/cluster/cluster_link.cpp
@@ -73,13 +73,17 @@ ClusterLink::restoreCheckpoint(const std::string& targetFilePath)
  * @param hexagonName name of the hexagon
  * @param input pointer to the list with the input-values
  * @param numberOfInputs number of input-values in the list
+ * @param bufferOffset offset within the input-buffer
+ * @param totalTimeLength total time-length to calculate the correct size of the buffer
  *
  * @return false, if hexagon with the name doesn't exist, else true
  */
 bool
 ClusterLink::fillInput(const std::string& hexagonName,
                        const float* input,
-                       const uint64_t numberOfInputs)
+                       const uint64_t numberOfInputs,
+                       const uint64_t bufferOffset,
+                       const uint64_t totalTimeLength)
 {
     auto it = m_cluster->inputInterfaces.find(hexagonName);
     if (it == m_cluster->inputInterfaces.end()) {
@@ -87,18 +91,17 @@ ClusterLink::fillInput(const std::string& hexagonName,
     }
 
     InputInterface* inputInterface = &it->second;
-    inputInterface->initBuffer(numberOfInputs, 1);
+    inputInterface->initBuffer(numberOfInputs, totalTimeLength);
 
     AxonBlock* axonBlock = nullptr;
     Axon* axon = nullptr;
     uint64_t blockId = 0;
     uint16_t axonId = 0;
-    uint64_t counter = 0;
+    uint64_t counter = bufferOffset;
     float val = 0.0f;
 
     for (uint64_t i = 0; i < numberOfInputs; ++i) {
         val = input[i];
-        // std::cout << "input: " << val << std::endl;
         blockId = counter / NEURONS_PER_BLOCK;
         axonId = counter % NEURONS_PER_BLOCK;
         axonBlock = &inputInterface->inputAxons[blockId];
@@ -108,7 +111,6 @@ ClusterLink::fillInput(const std::string& hexagonName,
         axon->potential = abs(val);
         counter += 2;
     }
-
     return true;
 }
 
@@ -132,7 +134,7 @@ ClusterLink::fillExpected(const std::string& hexagonName,
     }
 
     OutputInterface* outputInterface = &it->second;
-    outputInterface->initBuffer(numberOfOutputs, 1);
+    outputInterface->initBuffer(numberOfOutputs);
     convertBufferToExpected(outputInterface, output, numberOfOutputs);
 
     return true;

--- a/src/libs/cpp/hanami_core/src/cluster/objects.h
+++ b/src/libs/cpp/hanami_core/src/cluster/objects.h
@@ -279,10 +279,8 @@ struct OutputInterface {
     uint64_t size = 0;
     OutputType type = PLAIN_OUTPUT;
 
-    void initBuffer(uint64_t expectedSize, const uint64_t timeLength)
+    void initBuffer(uint64_t expectedSize)
     {
-        assert(timeLength >= 1);
-        expectedSize += (timeLength - 1);
         if (size != expectedSize) {
             size = expectedSize;
 
@@ -308,15 +306,15 @@ struct InputInterface {
     void initBuffer(uint64_t expectedSize, const uint64_t timeLength)
     {
         assert(timeLength >= 1);
+        expectedSize += (timeLength - 1);  // respect time-length of the input
         if (size != expectedSize) {
             size = expectedSize;
-            expectedSize += (timeLength - 1);  // respect time-length of the input
             expectedSize *= 2;  // double length to also hold a negative value for the inputs
             expectedSize /= NEURONS_PER_BLOCK;  // convert entries to blocks
             expectedSize++;  // becaus of the line above to fix rounding-error add a new block
 
             if (inputAxons.size() < expectedSize) {
-                const uint64_t oldSize = 0;
+                const uint64_t oldSize = inputAxons.size();
                 inputAxons.resize(expectedSize);
                 for (uint64_t i = oldSize; i < inputAxons.size(); i++) {
                     inputAxons[i] = AxonBlock();

--- a/src/libs/cpp/hanami_core/src/io/checkpoint/io_interface.cpp
+++ b/src/libs/cpp/hanami_core/src/io/checkpoint/io_interface.cpp
@@ -511,7 +511,7 @@ IO_Interface::deserializeHexagon(Hexagon& hexagon,
         outputIf.name = outputEntry.name.getName();
         outputIf.type = outputEntry.type;
         outputIf.targetHexagonId = hexagon.header.hexagonId;
-        outputIf.initBuffer(outputEntry.numberOfOutputs, 1);
+        outputIf.initBuffer(outputEntry.numberOfOutputs);
         outputIf.weightBlocks.resize(outputEntry.numberOfWeightBlocks);
 
         // read weight-blocks

--- a/src/libs/cpp/hanami_core/src/processing/cpu/core_backpropagation.h
+++ b/src/libs/cpp/hanami_core/src/processing/cpu/core_backpropagation.h
@@ -31,8 +31,6 @@
 
 #include <cmath>
 
-#include "hanami_root.h"
-
 /**
  * @brief backpropagate all neurons, which are not connected to
  *        an output-interface

--- a/src/libs/cpp/hanami_core/src/processing/cpu/core_processing.h
+++ b/src/libs/cpp/hanami_core/src/processing/cpu/core_processing.h
@@ -31,8 +31,6 @@
 
 #include <cmath>
 
-#include "hanami_root.h"
-
 /**
  * @brief process a single synapse-section
  *

--- a/src/libs/cpp/hanami_core/tests/unit_tests/core/cluster_io_convert_test.cpp
+++ b/src/libs/cpp/hanami_core/tests/unit_tests/core/cluster_io_convert_test.cpp
@@ -41,7 +41,7 @@ ClusterIOConvert_Test::convertPlain_test()
 {
     OutputInterface testInterface;
     testInterface.type = PLAIN_OUTPUT;
-    testInterface.initBuffer(4, 1);
+    testInterface.initBuffer(4);
 
     std::vector<float> buffer;
     buffer.resize(4);
@@ -79,7 +79,7 @@ ClusterIOConvert_Test::convertBool_test()
 {
     OutputInterface testInterface;
     testInterface.type = BOOL_OUTPUT;
-    testInterface.initBuffer(4, 1);
+    testInterface.initBuffer(4);
 
     std::vector<float> buffer;
     buffer.resize(4);
@@ -122,7 +122,7 @@ ClusterIOConvert_Test::convertFloat_test()
 {
     OutputInterface testInterface;
     testInterface.type = FLOAT_OUTPUT;
-    testInterface.initBuffer(2, 1);
+    testInterface.initBuffer(2);
 
     std::vector<float> buffer;
     buffer.resize(2);
@@ -156,7 +156,7 @@ ClusterIOConvert_Test::convertInt_test()
 {
     OutputInterface testInterface;
     testInterface.type = INT_OUTPUT;
-    testInterface.initBuffer(2, 1);
+    testInterface.initBuffer(2);
 
     std::vector<float> buffer;
     buffer.resize(2);

--- a/src/libs/cpp/hanami_core/tests/unit_tests/core/hanami_core_test.cpp
+++ b/src/libs/cpp/hanami_core/tests/unit_tests/core/hanami_core_test.cpp
@@ -65,8 +65,8 @@ Hanami_Core_Test::core_test()
 
     // set input
     float inputData[8] = {10.0, 0.0, 10.0, 0.0, 10.0, 0.0, 10.0, 0.0};
-    TEST_EQUAL(link->fillInput("fail", inputData, 8), false);
-    TEST_EQUAL(link->fillInput("input", inputData, 8), true);
+    TEST_EQUAL(link->fillInput("fail", inputData, 8, 0, 1), false);
+    TEST_EQUAL(link->fillInput("input", inputData, 8, 0, 1), true);
 
     // set expected-values on the outputs
     float expectedData[4] = {0.0, 1.0, 0.0, 1.0};

--- a/src/sdk/python/hanami_sdk/hanami_sdk/dataset.py
+++ b/src/sdk/python/hanami_sdk/hanami_sdk/dataset.py
@@ -80,23 +80,6 @@ def check_dataset(token: str,
                                            verify=verify_connection)
 
 
-def download_dataset_content(token: str,
-                             address: str,
-                             dataset_uuid: str,
-                             column_name: str,
-                             number_of_rows: int,
-                             row_offset: int = 0,
-                             verify_connection: bool = True) -> dict:
-    path = "/v1alpha/dataset/content"
-    values = f'uuid={dataset_uuid}&column_name={column_name}&row_offset={row_offset}' \
-        f'&number_of_rows={number_of_rows}'
-    return hanami_request.send_get_request(token,
-                                           address,
-                                           path,
-                                           values,
-                                           verify=verify_connection)
-
-
 def upload_mnist_files(token: str,
                        address: str,
                        name: str,

--- a/src/sdk/python/hanami_sdk/hanami_sdk/task.py
+++ b/src/sdk/python/hanami_sdk/hanami_sdk/task.py
@@ -32,7 +32,7 @@ def create_train_task(token: str,
         "number_of_epochs": number_of_epochs,
         "inputs": inputs,
         "outputs": outputs,
-        # "time_length": timeLength
+        "time_length": timeLength,
     }
     return hanami_request.send_post_request(token,
                                             address,
@@ -54,7 +54,7 @@ def create_request_task(token: str,
         "name": name,
         "inputs": inputs,
         "results": results,
-        # "time_length": timeLength
+        "time_length": timeLength,
     }
     return hanami_request.send_post_request(token,
                                             address,

--- a/testing/python_sdk_api/measure_tests.py
+++ b/testing/python_sdk_api/measure_tests.py
@@ -23,6 +23,26 @@ from hanami_sdk import task
 from hanami_sdk import direct_io
 import configparser
 import urllib3
+import time
+import sys
+import csv
+import json
+
+
+def progress_bar(epoch, total_epochs, cycle, total_cycles, prefix_epoch='', suffix_epoch='', prefix_cycle='', suffix_cycle='', length=50, fill='█'):
+    percent1 = "{0:.1f}".format(100 * (epoch / float(total_epochs)))
+    filled_length1 = int(length * epoch // total_epochs)
+    bar1 = fill * filled_length1 + '-' * (length - filled_length1)
+
+    percent2 = "{0:.1f}".format(100 * (cycle / float(total_cycles)))
+    filled_length2 = int(length * cycle // total_cycles)
+    bar2 = fill * filled_length2 + '-' * (length - filled_length2)
+
+    sys.stdout.write('\033[F')  # move cursor up one line
+    sys.stdout.write('\r%s |%s| %s%% %s\n' % (prefix_epoch, bar1, percent1, suffix_epoch))
+    sys.stdout.write('\r%s |%s| %s%% %s' % (prefix_cycle, bar2, percent2, suffix_cycle))
+    sys.stdout.flush()
+
 
 
 # the test use insecure connections, which is totally ok for the tests
@@ -39,26 +59,25 @@ address = config["connection"]["address"]
 test_user_id = config["connection"]["test_user"]
 test_user_pw = config["connection"]["test_passphrase"]
 
-train_inputs = "./train.csv"
-request_inputs = "./test.csv"
+train_inputs_file = "./train.csv"
+request_inputs_file = "./test.csv"
 
 cluster_template = \
-    "version: 1\n" \
-    "settings:\n" \
-    "   neuron_cooldown: 100000000.0\n" \
-    "   refractory_time: 1\n" \
-    "   max_connection_distance: 1\n" \
-    "    \n" \
-    "hexagons:\n" \
-    "    1,1,1\n" \
-    "    2,1,1\n" \
-    "    3,1,1\n" \
-    "    \n" \
-    "inputs:\n" \
-    "    test_input: 1,1,1\n" \
-    "\n" \
-    "outputs:\n" \
-    "    test_output: 3,1,1\n" \
+    "version: 42 " \
+    "settings: " \
+    "    neuron_cooldown: 1000000000.0; " \
+    "    refractory_time: 1; " \
+    "    max_connection_distance: 1; " \
+    "hexagons:  " \
+    "    1,1,1; " \
+    "    2,2,2; " \
+    "    3,2,2; " \
+    "axons: " \
+    "    1,1,1 -> 2,2,2;  " \
+    "inputs: " \
+    "    test_input: 1,1,1; " \
+    "outputs: " \
+    "    test_output: 3,2,2;"
 
 cluster_name = "test_cluster"
 generic_task_name = "test_task"
@@ -74,16 +93,16 @@ cluster.delete_all_cluster(token, address, False)
 
 # update dataset
 train_dataset_uuid = dataset.upload_csv_files(
-    token, address, train_dataset_name, train_inputs, False)
+    token, address, train_dataset_name, train_inputs_file, False)["uuid"]
 request_dataset_uuid = dataset.upload_csv_files(
-    token, address, request_dataset_name, request_inputs, False)
+    token, address, request_dataset_name, request_inputs_file, False)["uuid"]
 
 # define relations between data and cluster
 train_inputs = [
     {
         "dataset_uuid": train_dataset_uuid,
         "dataset_column": "test_input",
-        "hexagon_name": "test_input"
+        "hexagon": "test_input"
     }
 ]
 
@@ -91,29 +110,27 @@ train_outputs = [
     {
         "dataset_uuid": train_dataset_uuid,
         "dataset_column": "test_output",
-        "hexagon_name": "test_output"
+        "hexagon": "test_output"
     }
 ]
 
 request_inputs = [
     {
-        "dataset_uuid": request_dataset_uuid,
+        "dataset_uuid": train_dataset_uuid,
         "dataset_column": "test_input",
-        "hexagon_name": "test_input"
+        "hexagon": "test_input"
     }
 ]
 
-request_results = [
+request_outputs = [
     {
-        "dataset_column": "test_output",
-        "hexagon_name": "test_output"
+        "hexagon": "test_output"
     }
 ]
 
 replicas = 10
 cluster_uuids = [""] * 10
 task_uuids = [""] * 10
-result_outputs = [0.0] * 20
 flattened_list = [0.0] * 1750
 
 # create all cluster
@@ -122,35 +139,56 @@ for x in range(replicas):
         token, address, cluster_name + str(x), cluster_template, False)["uuid"]
 
 # train
-for i in range(0, 500):
-    for x in range(replicas):
-        print("poi: ", i)
-        task_uuids[x] = task.create_train_task(
-            token, address, generic_task_name, cluster_uuids[x], train_inputs, train_outputs, 20, False)["uuid"]
+for x in range(replicas):
+    print("train replica: ", x)
+    print('\n')
+    task_uuids[x] = task.create_train_task(
+        token, address, generic_task_name, cluster_uuids[x], train_inputs, train_outputs, 500, 20, False)["uuid"]
+    finished = False
+    while not finished:
+        time.sleep(1)
+        result = task.get_task(token, address, task_uuids[x], cluster_uuids[x], False)
+        # print(json.dumps(result, indent=4))
 
-    for x in range(replicas):
-        task.wait_for_task_finished(token, address, task_uuids[x], cluster_uuids[x], 0.01, False)
-        result = task.delete_task(token, address, task_uuids[x], cluster_uuids[x], False)
-
+        finished = result["state"] == "Finished" or result["state"] == "Error"
+        progress_bar(result["current_epoch"],
+                     result["total_number_of_epochs"],
+                     result["current_cycle"],
+                     result["total_number_of_cycles"],
+                     prefix_epoch='Epoch:',
+                     suffix_epoch='Complete',
+                     prefix_cycle='Cycle:',
+                     suffix_cycle='Complete',
+                     length=50)
+    
 # test
 for x in range(replicas):
-    task_uuids[x] = task.create_request_task(
-        token, address, generic_task_name, cluster_uuids[x], request_inputs, request_results, 20, False)["uuid"]
-    task.wait_for_task_finished(token, address, task_uuids[x], cluster_uuids[x], 0.01, False)
+    print("test replica: ", x)
+    with open(request_inputs_file, mode='r') as file:
+        reader = csv.reader(file)
+        
+        # skip the header if there is one
+        next(reader)
+        output_names = ["test_output"]
 
-    data = dataset.download_dataset_content(
-        token, address, task_uuids[x], "test_output", 1700, 0, False)["data"]
+        # read all rows into a list
+        rows = list(reader)
+        
+        for index, _ in enumerate(rows[:-20]):
+            values = list()
+            for offset in range(0, 20):
+                values.append(float(rows[index + offset][0]))
+            inputs = dict()
+            inputs["test_input"] = values
 
-    # print(data)
-    temp_list = [item for sublist in data for item in sublist]
-    for r in range(len(temp_list)):
-        flattened_list[r] += temp_list[r]
+            output_values = cluster.request(token, address, cluster_uuids[x], inputs, output_names, False)
+            out_val = json.dumps(output_values["outputs"]["test_output"][0], indent=4)
+            flattened_list[index] += float(out_val)
 
 # delete everything again
 for x in range(replicas):
     cluster.delete_cluster(token, address, cluster_uuids[x], False)
 dataset.delete_dataset(token, address, train_dataset_uuid, False)
-dataset.delete_dataset(token, address, request_dataset_uuid, False)
 
 # update result
 for r in range(len(flattened_list)):


### PR DESCRIPTION


## Pull Request

### Description
The time-length value was added again for tasks
to allow a sequence of rows of a dataset as input. Also fixed the measurement-tests again for the new backend.
<!-- A concise description of the content of the pull-request -->

### Related Issues

- #567 
<!-- In context of which issues the changes of this pull request were created. -->

### How it was tested?

- sdk-api-test and new measurement-test
<!-- What parts and how they were tested -->
