### PR TITLE
fix(#647): fixed deadlock in bigger cluster

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -15,7 +15,8 @@
                 // test-env-variables to initialize a basic user for testing
                 "HANAMI_ADMIN_ID": "asdf",
                 "HANAMI_ADMIN_NAME": "asdf",
-                "HANAMI_ADMIN_PASSPHRASE": "asdfasdf"
+                "HANAMI_ADMIN_PASSPHRASE": "asdfasdf",
+                "RUST_BACKTRACE": "full"
             },
         },
         {

--- a/src/binaries/hanami/src/core/blocks/axons.rs
+++ b/src/binaries/hanami/src/core/blocks/axons.rs
@@ -46,6 +46,7 @@ pub struct AxonSection {
 
     pub target_pos: u8,
     pub source_pos: u8,
+    pub done: bool,
 
     #[serde(skip)]
     pub source_block: Option<Arc<Mutex<dyn Block>>>,
@@ -66,6 +67,7 @@ impl AxonSection {
             source_pos: UNINIT_STATE_8,
             source_block: None,
             target_block: None,
+            done: false,
         }
     }
 }
@@ -80,6 +82,7 @@ impl PartialEq for AxonSection {
             && self.target_block_uuid == other.target_block_uuid
             && self.target_pos == other.target_pos
             && self.source_pos == other.source_pos
+            && self.done == other.done
     }
 }
 
@@ -102,6 +105,7 @@ mod tests {
             source_pos: 43,
             source_block: None,
             target_block: None,
+            done: false,
         };
         original.axons[42].potential = 123.0f32;
         original.axons[42].delta = 124.0f32;

--- a/src/binaries/hanami/src/core/blocks/block_io.rs
+++ b/src/binaries/hanami/src/core/blocks/block_io.rs
@@ -54,7 +54,7 @@ pub fn connect_outputs(
             axon_section.source_pos = i as u8;
 
             // cluster_handler.get_target(axon_section);
-            connect_to_target(axon_section)?;
+            connect_to_new_target(axon_section)?;
         } else if axon_section.source_block.is_none() || axon_section.target_block.is_none() {
             let cluster_handler = CLUSTER_HANDLER.read().unwrap();
             axon_section.cluster_uuid = *cluster_uuid;
@@ -76,17 +76,18 @@ pub fn connect_outputs(
 
 pub fn send_forward(io_buffer: &BlockIoBuffer, task_type: WorkerTaskType, cycle_number: u64) {
     // send outputs to target
-    let mut worker_queue = WORKER_QUEUE.lock().unwrap();
     for axon_section in io_buffer.output_buffer.iter() {
         let target_block_mutex = if let Some(t) = &axon_section.target_block {
             t
         } else {
             continue;
         };
-        let block_clone = Arc::clone(target_block_mutex);
+
         let mut target_block = target_block_mutex.lock().unwrap();
         let target_bock_io = target_block.get_block_io();
+        let is_done = target_bock_io.input_buffer[axon_section.target_pos as usize].done;
         target_bock_io.input_buffer[axon_section.target_pos as usize] = axon_section.clone();
+        target_bock_io.input_buffer[axon_section.target_pos as usize].done = is_done;
         target_bock_io.input_buffer_counter += 1;
 
         if target_bock_io.input_buffer_counter >= target_bock_io.inputs_in_use {
@@ -94,18 +95,18 @@ pub fn send_forward(io_buffer: &BlockIoBuffer, task_type: WorkerTaskType, cycle_
 
             let worker_task = WorkerTask {
                 task_type: task_type.clone(),
-                block: block_clone,
+                block: Arc::clone(target_block_mutex),
                 cycle_number,
             };
 
+            let mut worker_queue = WORKER_QUEUE.lock().unwrap();
             worker_queue.add(worker_task);
         }
     }
 }
 
-pub fn send_backward(io_buffer: &BlockIoBuffer, cycle_number: u64) {
-    let mut worker_queue = WORKER_QUEUE.lock().unwrap();
-    for axon_section in io_buffer.input_buffer.iter() {
+pub fn send_backward(io_buffer: &mut BlockIoBuffer, cycle_number: u64) -> bool {
+    for axon_section in io_buffer.input_buffer.iter_mut() {
         let source_block_mutex = if let Some(s) = &axon_section.source_block {
             s
         } else {
@@ -113,23 +114,74 @@ pub fn send_backward(io_buffer: &BlockIoBuffer, cycle_number: u64) {
         };
 
         // send axon-sections to target-block and create new worker-task
-        let mut source_block = source_block_mutex.lock().unwrap();
-        let target_bock_io = source_block.get_block_io();
-        target_bock_io.output_buffer[axon_section.source_pos as usize] = axon_section.clone();
-        target_bock_io.output_buffer_counter += 1;
+        if let Ok(mut source_block) = source_block_mutex.lock() {
+            let target_bock_io = source_block.get_block_io();
+            target_bock_io.output_buffer[axon_section.source_pos as usize] = axon_section.clone();
+            target_bock_io.output_buffer_counter += 1;
 
-        if target_bock_io.output_buffer_counter >= target_bock_io.output_buffer.len() as u64 {
-            target_bock_io.output_buffer_counter = 0;
+            if target_bock_io.output_buffer_counter >= target_bock_io.output_buffer.len() as u64 {
+                target_bock_io.output_buffer_counter = 0;
 
-            let worker_task = WorkerTask {
-                task_type: WorkerTaskType::Backpropagate,
-                block: Arc::clone(source_block_mutex),
-                cycle_number,
-            };
+                let worker_task = WorkerTask {
+                    task_type: WorkerTaskType::Backpropagate,
+                    block: Arc::clone(source_block_mutex),
+                    cycle_number,
+                };
 
-            worker_queue.add(worker_task);
+                let mut worker_queue = WORKER_QUEUE.lock().unwrap();
+                worker_queue.add(worker_task);
+            }
+            axon_section.done = true;
         }
     }
+
+    true
+}
+
+pub fn send_backward_with_retry(io_buffer: &mut BlockIoBuffer, cycle_number: u64) -> bool {
+    for axon_section in io_buffer.input_buffer.iter_mut() {
+        if axon_section.done {
+            continue;
+        }
+
+        let source_block_mutex = if let Some(s) = &axon_section.source_block {
+            s
+        } else {
+            continue;
+        };
+
+        // send axon-sections to target-block and create new worker-task
+        if let Ok(mut source_block) = source_block_mutex.try_lock() {
+            let target_bock_io = source_block.get_block_io();
+            let is_done = target_bock_io.output_buffer[axon_section.source_pos as usize].done;
+            target_bock_io.output_buffer[axon_section.source_pos as usize] = axon_section.clone();
+            target_bock_io.output_buffer[axon_section.source_pos as usize].done = is_done;
+            target_bock_io.output_buffer_counter += 1;
+
+            if target_bock_io.output_buffer_counter >= target_bock_io.output_buffer.len() as u64 {
+                target_bock_io.output_buffer_counter = 0;
+
+                let worker_task = WorkerTask {
+                    task_type: WorkerTaskType::Backpropagate,
+                    block: Arc::clone(source_block_mutex),
+                    cycle_number,
+                };
+
+                let mut worker_queue = WORKER_QUEUE.lock().unwrap();
+                worker_queue.add(worker_task);
+            }
+            axon_section.done = true;
+        } else {
+            axon_section.done = false;
+            return false;
+        }
+    }
+
+    for axon_section in io_buffer.input_buffer.iter_mut() {
+        axon_section.done = false;
+    }
+
+    true
 }
 
 #[cfg(test)]

--- a/src/binaries/hanami/src/core/blocks/block_trait.rs
+++ b/src/binaries/hanami/src/core/blocks/block_trait.rs
@@ -40,6 +40,10 @@ pub trait Block: Send + Sync + Debug {
         cycle_number: u64,
     ) -> Result<Option<Arc<Mutex<FinishCounter>>>, AinariError>;
 
+    fn finalize_train(&mut self, cycle_number: u64) -> Result<(), AinariError>;
+    fn finalize_process(&mut self, cycle_number: u64) -> Result<(), AinariError>;
+    fn finalize_backpropagate(&mut self, cycle_number: u64) -> Result<bool, AinariError>;
+
     fn get_free_input(&mut self, axon_section: &mut AxonSection) -> bool;
     fn get_uuid(&self) -> Uuid;
     fn get_hexagon_uud(&self) -> Uuid;

--- a/src/binaries/hanami/src/core/blocks/core_block.rs
+++ b/src/binaries/hanami/src/core/blocks/core_block.rs
@@ -400,6 +400,10 @@ fn backpropagate_section(
             break;
         }
 
+        if synapse.target_neuron_id == UNINIT_STATE_16 {
+            break;
+        }
+
         output_block_id =
             ((synapse.target_neuron_id / BLOCK_DIM as u16) as usize) % output_buffer.len();
         output_axon_id = (synapse.target_neuron_id % BLOCK_DIM as u16) as usize;
@@ -427,7 +431,7 @@ impl Block for CoreBlock {
         &mut self,
         _: usize,
         _: Arc<Mutex<dyn Block>>,
-        cycle_number: u64,
+        _: u64,
     ) -> Result<Option<Arc<Mutex<FinishCounter>>>, AinariError> {
         self.check_and_resize_block();
         let number_of_output_blocks = self.block_io.output_buffer.len();
@@ -477,21 +481,11 @@ impl Block for CoreBlock {
         }
 
         self.apply_output();
-        connect_outputs(
-            &mut self.block_io,
-            &self.cluster_uuid,
-            &self.hexagon_uuid,
-            &self.uuid,
-        )?;
-        send_forward(&self.block_io, WorkerTaskType::Train, cycle_number);
 
         Ok(None)
     }
 
-    fn process(
-        &mut self,
-        cycle_number: u64,
-    ) -> Result<Option<Arc<Mutex<FinishCounter>>>, AinariError> {
+    fn process(&mut self, _: u64) -> Result<Option<Arc<Mutex<FinishCounter>>>, AinariError> {
         self.check_and_resize_block();
         let number_of_output_blocks = self.block_io.output_buffer.len();
 
@@ -519,21 +513,11 @@ impl Block for CoreBlock {
         }
 
         self.apply_output();
-        connect_outputs(
-            &mut self.block_io,
-            &self.cluster_uuid,
-            &self.hexagon_uuid,
-            &self.uuid,
-        )?;
-        send_forward(&self.block_io, WorkerTaskType::Process, cycle_number);
 
         Ok(None)
     }
 
-    fn backpropagate(
-        &mut self,
-        cycle_number: u64,
-    ) -> Result<Option<Arc<Mutex<FinishCounter>>>, AinariError> {
+    fn backpropagate(&mut self, _: u64) -> Result<Option<Arc<Mutex<FinishCounter>>>, AinariError> {
         // // experimental stuff
         // for axon_section in self.block_io.input_buffer.iter_mut() {
         //     for axon in axon_section.axons.iter_mut() {
@@ -555,9 +539,37 @@ impl Block for CoreBlock {
             }
         }
 
-        send_backward(&self.block_io, cycle_number);
-
         Ok(None)
+    }
+
+    fn finalize_train(&mut self, cycle_number: u64) -> Result<(), AinariError> {
+        connect_outputs(
+            &mut self.block_io,
+            &self.cluster_uuid,
+            &self.hexagon_uuid,
+            &self.uuid,
+        )?;
+        send_forward(&self.block_io, WorkerTaskType::Train, cycle_number);
+
+        Ok(())
+    }
+
+    fn finalize_process(&mut self, cycle_number: u64) -> Result<(), AinariError> {
+        connect_outputs(
+            &mut self.block_io,
+            &self.cluster_uuid,
+            &self.hexagon_uuid,
+            &self.uuid,
+        )?;
+        send_forward(&self.block_io, WorkerTaskType::Process, cycle_number);
+
+        Ok(())
+    }
+
+    fn finalize_backpropagate(&mut self, cycle_number: u64) -> Result<bool, AinariError> {
+        let ret = send_backward_with_retry(&mut self.block_io, cycle_number);
+
+        Ok(ret)
     }
 
     fn get_free_input(&mut self, axon_section: &mut AxonSection) -> bool {

--- a/src/binaries/hanami/src/core/blocks/input_block.rs
+++ b/src/binaries/hanami/src/core/blocks/input_block.rs
@@ -147,9 +147,23 @@ impl Block for InputBlock {
         &mut self,
         _: usize,
         _: Arc<Mutex<dyn Block>>,
-        cycle_number: u64,
+        _: u64,
     ) -> Result<Option<Arc<Mutex<FinishCounter>>>, AinariError> {
         self.local_finish_counter = 0;
+        Ok(None)
+    }
+
+    fn process(&mut self, _: u64) -> Result<Option<Arc<Mutex<FinishCounter>>>, AinariError> {
+        self.local_finish_counter = 0;
+
+        Ok(None)
+    }
+
+    fn backpropagate(&mut self, _: u64) -> Result<Option<Arc<Mutex<FinishCounter>>>, AinariError> {
+        Ok(Some(self.finish_counter_mutex.clone()))
+    }
+
+    fn finalize_train(&mut self, cycle_number: u64) -> Result<(), AinariError> {
         connect_outputs(
             &mut self.block_io,
             &self.cluster_uuid,
@@ -158,14 +172,10 @@ impl Block for InputBlock {
         )?;
         send_forward(&self.block_io, WorkerTaskType::Train, cycle_number);
 
-        Ok(None)
+        Ok(())
     }
 
-    fn process(
-        &mut self,
-        cycle_number: u64,
-    ) -> Result<Option<Arc<Mutex<FinishCounter>>>, AinariError> {
-        self.local_finish_counter = 0;
+    fn finalize_process(&mut self, cycle_number: u64) -> Result<(), AinariError> {
         connect_outputs(
             &mut self.block_io,
             &self.cluster_uuid,
@@ -174,11 +184,11 @@ impl Block for InputBlock {
         )?;
         send_forward(&self.block_io, WorkerTaskType::Process, cycle_number);
 
-        Ok(None)
+        Ok(())
     }
 
-    fn backpropagate(&mut self, _: u64) -> Result<Option<Arc<Mutex<FinishCounter>>>, AinariError> {
-        Ok(Some(self.finish_counter_mutex.clone()))
+    fn finalize_backpropagate(&mut self, _: u64) -> Result<bool, AinariError> {
+        Ok(true)
     }
 
     fn get_free_input(&mut self, _: &mut AxonSection) -> bool {

--- a/src/binaries/hanami/src/core/blocks/new_core_block.rs
+++ b/src/binaries/hanami/src/core/blocks/new_core_block.rs
@@ -1,574 +1,574 @@
-// Copyright 2022 Tobias Anker <tobias.anker@kitsunemimi.moe>
-
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-
-//     http://www.apache.org/licenses/LICENSE-2.0
-
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
-use rand::Rng;
-use std::sync::{Arc, Mutex};
-use uuid::Uuid;
-
-use ainari_common::constants::*;
-use ainari_common::enums::*;
-use ainari_common::error::AinariError;
-
-use crate::core::processing::finish_counter::FinishCounter;
-
-use super::axons::*;
-use super::block_io::*;
-use super::block_trait::*;
-
-use super::super::processing::worker_queue::*;
-
-// ==================================================================================================
-
-#[derive(Debug, Clone, Copy)]
-pub struct Synapse {
-    pub weight: f32,
-    pub upper: f32,
-    pub lower: f32,
-    pub layer: u8,
-
-    pub active_counter: u8,
-    pub source_axon: u8,
-
-    pub active_counter_top: u8,
-    pub active_counter_lower: u8,
-    pub active_counter_upper: u8,
-}
-
-impl Synapse {
-    pub fn default() -> Self {
-        Synapse {
-            weight: rand::rng().random_range(-0.5..=0.5),
-
-            active_counter: 0,
-            source_axon: UNINIT_STATE_8,
-
-            upper: 2.0f32,
-            lower: 0.0f32,
-            layer: 0,
-
-            active_counter_top: 0,
-            active_counter_lower: 0,
-            active_counter_upper: 0,
-        }
-    }
-}
-
-// ==================================================================================================
-
-#[derive(Debug, Clone, Copy)]
-pub struct Neuron {
-    pub input: f32,
-    // pub refraction_time: u8,
-}
-
-impl Neuron {
-    #[allow(dead_code)]
-    pub fn default() -> Self {
-        Neuron {
-            input: 0.0f32,
-            // refraction_time: 0,
-        }
-    }
-}
-
-// ==================================================================================================
-
-#[derive(Debug, Clone)]
-pub struct NewCoreBlock {
-    pub uuid: Uuid,
-    pub hexagon_uuid: Uuid,
-    pub cluster_uuid: Uuid,
-
-    // HINT (kitsudaiki): this has to be a Box instead of a static array to avoid a stack-overflow, because the object is too big
-    pub synapses: Box<[Synapse]>,
-    pub buffer: [Synapse; BLOCK_DIM * 3],
-    pub neurons: [Neuron; BLOCK_DIM * 3],
-    pub fill_size: [u8; BLOCK_DIM * 3],
-
-    pub synapse_counter: u64,
-
-    pub block_io: BlockIoBuffer,
-}
-
-impl NewCoreBlock {
-    #[allow(dead_code)]
-    pub fn new(hexagon_uuid: &Uuid, cluster_uuid: &Uuid) -> Self {
-        // internal visilization of the blocks:
-        //
-        // +---+ +---+ +---+
-        // | 1 | | 3 | | 5 |
-        // +---+ +---+ +---+
-        // | 0 | | 2 | | 4 |
-        // +---+ +---+ +---+
-        //
-        let capacity = BLOCK_DIM * 2 * BLOCK_DIM * 3;
-        let mut vec = Vec::with_capacity(capacity);
-        for _ in 0..capacity {
-            vec.push(Synapse::default());
-        }
-
-        // set initial state
-        let mut counter = 0_usize;
-        let mut fill_size = std::array::from_fn(|_| 0u8);
-        for (x_offset, fill_size) in fill_size.iter_mut().enumerate().take(BLOCK_DIM) {
-            *fill_size = 2;
-            for y_offset in 0..(*fill_size as usize) {
-                let synapse_pos = (x_offset * 2 * BLOCK_DIM) + y_offset;
-                let synapse = &mut vec[synapse_pos];
-                synapse.source_axon = counter as u8;
-                synapse.lower = 0.0f32;
-                synapse.upper = 2.0f32;
-                synapse.active_counter = 255;
-                counter += 1;
-            }
-        }
-
-        let mut block = NewCoreBlock {
-            uuid: Uuid::new_v4(),
-            hexagon_uuid: *hexagon_uuid,
-            cluster_uuid: *cluster_uuid,
-
-            block_io: BlockIoBuffer::default(),
-
-            synapses: vec.into_boxed_slice(),
-            buffer: std::array::from_fn(|_| Synapse::default()),
-            neurons: std::array::from_fn(|_| Neuron::default()),
-            fill_size,
-
-            // pre-initialized number of synapses, one for each possible input-axon
-            synapse_counter: 256,
-        };
-
-        block.block_io.output_buffer.push(AxonSection::default());
-        block.block_io.input_buffer.push(AxonSection::default());
-        block.block_io.input_buffer.push(AxonSection::default());
-        block.block_io.inputs_in_use = 0;
-
-        block
-    }
-
-    fn handle_buffer(&mut self) {
-        for x_offset in 0..(self.block_io.output_buffer.len() * BLOCK_DIM) {
-            if self.buffer[x_offset].source_axon != UNINIT_STATE_8 {
-                let current_fill_size = self.fill_size[x_offset];
-
-                if current_fill_size < ((2 * BLOCK_DIM) - 2) as u8 {
-                    let synapse_offset = (x_offset * 2 * BLOCK_DIM) + current_fill_size as usize;
-                    self.synapses[synapse_offset] = self.buffer[x_offset];
-                    self.buffer[x_offset] = Synapse::default();
-
-                    self.fill_size[x_offset] += 1;
-                    self.synapse_counter += 1;
-                }
-            }
-        }
-    }
-
-    fn check_and_resize_block(&mut self) {
-        // resize block in case it is filled enough
-        if self.block_io.output_buffer.len() == 1
-            && self.synapse_counter as f32 >= ((BLOCK_DIM * BLOCK_DIM) as f32 * 0.9f32)
-        {
-            self.block_io.output_buffer.push(AxonSection::default());
-        }
-        if self.block_io.output_buffer.len() == 2
-            && self.synapse_counter as f32 >= ((BLOCK_DIM * BLOCK_DIM * 2) as f32 * 0.9f32)
-        {
-            self.block_io.output_buffer.push(AxonSection::default());
-        }
-    }
-
-    fn apply_output(&mut self) {
-        let mut counter = 0;
-        for o in 0..self.block_io.output_buffer.len() {
-            for i in 0..BLOCK_DIM {
-                self.block_io.output_buffer[o].axons[i].potential = self.neurons[counter].input;
-                counter += 1;
-            }
-        }
-    }
-}
-
-// ==================================================================================================
-
-impl Block for NewCoreBlock {
-    fn train(
-        &mut self,
-        place_offset: usize,
-        _: Arc<Mutex<dyn Block>>,
-        cycle_number: u64,
-    ) -> Result<Option<Arc<Mutex<FinishCounter>>>, AinariError> {
-        self.handle_buffer();
-        self.check_and_resize_block();
-
-        // // debug-output
-        // println!("core-buffer-axons: ");
-        // for axon in self.input_buffer[0].axons.iter_mut() {
-        //     print!("{} ", axon.potential);
-        // }
-        // println!(" ");
-
-        let number_of_output_blocks = self.block_io.output_buffer.len();
-        for x_offset in 0..(number_of_output_blocks * BLOCK_DIM) {
-            let neuron = &mut self.neurons[x_offset];
-            neuron.input = 0.0f32;
-
-            for y_offset in 0..(self.fill_size[x_offset] as usize) {
-                // get values
-                let synapse_pos = (x_offset * 2 * BLOCK_DIM) + y_offset;
-                let synapse = &mut self.synapses[synapse_pos];
-                let source_potential = self.block_io.input_buffer
-                    [synapse.source_axon as usize / BLOCK_DIM]
-                    .axons[synapse.source_axon as usize % BLOCK_DIM]
-                    .potential;
-                if source_potential <= 0.0f32 {
-                    continue;
-                }
-                let third = (synapse.upper - synapse.lower) / 3.0f32;
-
-                // update current synapse
-                let update = (source_potential > synapse.lower) as u8;
-                neuron.input += synapse.weight * update as f32;
-                synapse.active_counter += update * (synapse.active_counter < 254) as u8;
-
-                if synapse.layer < 6 {
-                    // handling first layer split
-                    if synapse.layer == 0
-                        && synapse.active_counter_top == 0
-                        && source_potential > synapse.upper
-                    {
-                        let mut new_synapse = Synapse::default();
-                        new_synapse.source_axon = synapse.source_axon;
-                        new_synapse.upper =
-                            ((synapse.upper - new_synapse.lower) * 2.0f32) + synapse.upper;
-                        new_synapse.lower = synapse.upper;
-                        new_synapse.layer = 0;
-                        let pos = (place_offset + x_offset) % (number_of_output_blocks * BLOCK_DIM);
-                        if self.buffer[pos].source_axon == UNINIT_STATE_8 {
-                            self.buffer[pos] = new_synapse;
-                            synapse.active_counter_top = 1;
-                        }
-                    }
-
-                    // handle upper split
-                    if synapse.active_counter_upper == 0
-                        && source_potential <= synapse.upper
-                        && source_potential > synapse.upper - third
-                    {
-                        let mut new_synapse = Synapse::default();
-                        new_synapse.source_axon = synapse.source_axon;
-                        new_synapse.upper = synapse.upper;
-                        new_synapse.lower = synapse.upper - third;
-                        new_synapse.layer = synapse.layer + 1;
-                        let pos = (place_offset + x_offset) % (number_of_output_blocks * BLOCK_DIM);
-                        if self.buffer[pos].source_axon == UNINIT_STATE_8 {
-                            self.buffer[pos] = new_synapse;
-                            synapse.active_counter_upper = 1;
-                        }
-                    }
-
-                    // handle lower split
-                    if synapse.active_counter_lower == 0
-                        && source_potential > synapse.lower
-                        && source_potential <= synapse.lower + third
-                    {
-                        let mut new_synapse = Synapse::default();
-                        new_synapse.source_axon = synapse.source_axon;
-                        new_synapse.upper = synapse.lower + third;
-                        new_synapse.lower = synapse.lower;
-                        new_synapse.layer = synapse.layer + 1;
-                        let pos = (place_offset + x_offset) % (number_of_output_blocks * BLOCK_DIM);
-                        if self.buffer[pos].source_axon == UNINIT_STATE_8 {
-                            self.buffer[pos] = new_synapse;
-                            synapse.active_counter_lower = 1;
-                        }
-                    }
-                }
-            }
-
-            // TODO: handle refraction-type and node-cooldown of neuron
-        }
-
-        self.apply_output();
-        connect_outputs(
-            &mut self.block_io,
-            &self.cluster_uuid,
-            &self.hexagon_uuid,
-            &self.uuid,
-        )?;
-        send_forward(&self.block_io, WorkerTaskType::Train, cycle_number);
-
-        Ok(None)
-    }
-
-    fn process(
-        &mut self,
-        cycle_number: u64,
-    ) -> Result<Option<Arc<Mutex<FinishCounter>>>, AinariError> {
-        // // debug-output
-        // println!("core-buffer-axons: ");
-        // for axon in self.input_buffer[0].axons.iter_mut() {
-        //     print!("{} ", axon.potential);
-        // }
-        // println!(" ");
-
-        let number_of_output_blocks = self.block_io.output_buffer.len();
-        for x_offset in 0..(number_of_output_blocks * BLOCK_DIM) {
-            let neuron = &mut self.neurons[x_offset];
-            neuron.input = 0.0f32;
-
-            for y_offset in 0..(self.fill_size[x_offset] as usize) {
-                // get values
-                let synapse_pos = (x_offset * 2 * BLOCK_DIM) + y_offset;
-                let synapse = &mut self.synapses[synapse_pos];
-                let source_weight = self.block_io.input_buffer
-                    [synapse.source_axon as usize / BLOCK_DIM]
-                    .axons[synapse.source_axon as usize % BLOCK_DIM]
-                    .potential;
-
-                // update current synapse
-                let update = (source_weight > synapse.lower) as u8;
-                neuron.input += synapse.weight * update as f32;
-                synapse.active_counter += update * (synapse.active_counter < 254) as u8;
-            }
-
-            // TODO: handle refraction-type and node-cooldown of neuron
-        }
-        self.apply_output();
-        send_forward(&self.block_io, WorkerTaskType::Process, cycle_number);
-
-        Ok(None)
-    }
-
-    fn backpropagate(
-        &mut self,
-        cycle_number: u64,
-    ) -> Result<Option<Arc<Mutex<FinishCounter>>>, AinariError> {
-        let train_value = 0.1f32;
-
-        let number_of_output_blocks = self.block_io.output_buffer.len();
-        for x_offset in 0..(number_of_output_blocks * BLOCK_DIM) {
-            let target_axon =
-                &mut self.block_io.output_buffer[x_offset / BLOCK_DIM].axons[x_offset % BLOCK_DIM];
-            if target_axon.delta == 0.0f32 {
-                continue;
-            }
-
-            for y_offset in 0..(self.fill_size[x_offset] as usize) {
-                let synapse = &mut self.synapses[(x_offset * 2 * BLOCK_DIM) + y_offset];
-                let source_axon = &mut self.block_io.input_buffer
-                    [synapse.source_axon as usize / BLOCK_DIM]
-                    .axons[synapse.source_axon as usize % BLOCK_DIM];
-                let update = (source_axon.potential > synapse.lower) as u8;
-                let delta = target_axon.delta * synapse.weight * update as f32;
-                synapse.weight -= train_value * target_axon.delta;
-                source_axon.delta += delta;
-            }
-
-            target_axon.delta = 0.0f32;
-        }
-
-        send_backward(&self.block_io, cycle_number);
-
-        Ok(None)
-    }
-
-    fn get_free_input(&mut self, axon_section: &mut AxonSection) -> bool {
-        if self.block_io.inputs_in_use == 0 {
-            axon_section.target_block_uuid = self.uuid;
-            axon_section.target_hexagon_uuid = self.hexagon_uuid;
-            axon_section.target_pos = 0;
-            self.block_io.input_buffer[0] = axon_section.clone();
-            self.block_io.inputs_in_use = 1;
-            return true;
-        }
-
-        if self.block_io.inputs_in_use == 1 {
-            axon_section.target_block_uuid = self.uuid;
-            axon_section.target_hexagon_uuid = self.hexagon_uuid;
-            axon_section.target_pos = 1;
-            self.block_io.input_buffer[1] = axon_section.clone();
-            self.block_io.inputs_in_use = 2;
-            return true;
-        }
-
-        false
-    }
-
-    fn get_uuid(&self) -> Uuid {
-        self.uuid
-    }
-
-    fn get_hexagon_uud(&self) -> Uuid {
-        self.hexagon_uuid
-    }
-    fn get_cluster_uud(&self) -> Uuid {
-        self.cluster_uuid
-    }
-
-    fn get_block_io(&mut self) -> &mut BlockIoBuffer {
-        &mut self.block_io
-    }
-
-    fn get_type(&self) -> ObjectType {
-        ObjectType::Unknown
-    }
-
-    fn set_cluster_uuid(&mut self, new_cluster_uuid: &Uuid) {
-        self.cluster_uuid = *new_cluster_uuid;
-    }
-
-    fn serailize(&self) -> Vec<u8> {
-        Vec::new()
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use uuid::Uuid;
-
-    use ainari_common::constants::*;
-
-    use super::*;
-
-    #[test]
-    fn test_process() {
-        let cluster_uuid = Uuid::new_v4();
-        let hexagon_uuid = Uuid::new_v4();
-        let mut test_block = NewCoreBlock::new(&hexagon_uuid, &cluster_uuid);
-        test_block.buffer[1].source_axon = 42;
-        let own: Arc<Mutex<dyn Block>> = Arc::new(Mutex::new(test_block.clone()));
-        let cycle_number = 0;
-
-        let mut test_axon = AxonSection::default();
-        test_axon.axons[0].potential = 10.0f32;
-
-        test_block.block_io.input_buffer[0] = test_axon;
-
-        let _ = test_block.train(42, Arc::clone(&own), cycle_number);
-
-        // check if buffer-processing works correctly
-        assert_eq!(test_block.fill_size[1], 3);
-        assert_eq!(test_block.buffer[1].source_axon, UNINIT_STATE_8);
-        assert_eq!(test_block.synapses[2 * BLOCK_DIM + 2].source_axon, 42);
-        assert_eq!(test_block.synapse_counter, 257);
-
-        // run processing in order to create new synapses
-        let _ = test_block.train(42, Arc::clone(&own), cycle_number);
-        assert_eq!(test_block.synapse_counter, 258);
-        let _ = test_block.train(42, Arc::clone(&own), cycle_number);
-        assert_eq!(test_block.synapse_counter, 259);
-        let _ = test_block.train(42, Arc::clone(&own), cycle_number);
-        assert_eq!(test_block.synapse_counter, 260);
-        let _ = test_block.train(42, Arc::clone(&own), cycle_number);
-        assert_eq!(test_block.synapse_counter, 261);
-        let _ = test_block.train(42, Arc::clone(&own), cycle_number);
-        assert_eq!(test_block.synapse_counter, 262);
-        let _ = test_block.train(42, Arc::clone(&own), cycle_number);
-        assert_eq!(test_block.synapse_counter, 263);
-        let _ = test_block.train(42, Arc::clone(&own), cycle_number);
-        assert_eq!(test_block.synapse_counter, 264);
-        let _ = test_block.train(42, Arc::clone(&own), cycle_number);
-        assert_eq!(test_block.synapse_counter, 265);
-        // after depth = 8, nothing more will be added
-        let _ = test_block.train(42, Arc::clone(&own), cycle_number);
-        assert_eq!(test_block.synapse_counter, 265);
-
-        // check fill-size
-        assert_eq!(test_block.fill_size[1], 3);
-        assert_eq!(test_block.fill_size[42], 3);
-        assert_eq!(test_block.fill_size[84], 3);
-        assert_eq!(test_block.fill_size[126], 3);
-        assert_eq!(test_block.fill_size[40], 3);
-        assert_eq!(test_block.fill_size[82], 3);
-        assert_eq!(test_block.fill_size[124], 3);
-        assert_eq!(test_block.fill_size[38], 3);
-        assert_eq!(test_block.fill_size[80], 3);
-        assert_eq!(test_block.fill_size[122], 2);
-
-        // check that affected neurons have input
-        assert_ne!(test_block.neurons[84].input, 0.0f32);
-        assert_ne!(test_block.neurons[126].input, 0.0f32);
-        assert_ne!(test_block.neurons[40].input, 0.0f32);
-        assert_ne!(test_block.neurons[82].input, 0.0f32);
-        assert_ne!(test_block.neurons[124].input, 0.0f32);
-        assert_ne!(test_block.neurons[38].input, 0.0f32);
-        assert_ne!(test_block.neurons[80].input, 0.0f32);
-        assert_ne!(
-            test_block.block_io.output_buffer[0].axons[84].potential,
-            0.0f32
-        );
-        assert_ne!(
-            test_block.block_io.output_buffer[0].axons[126].potential,
-            0.0f32
-        );
-        assert_ne!(
-            test_block.block_io.output_buffer[0].axons[40].potential,
-            0.0f32
-        );
-        assert_ne!(
-            test_block.block_io.output_buffer[0].axons[82].potential,
-            0.0f32
-        );
-        assert_ne!(
-            test_block.block_io.output_buffer[0].axons[124].potential,
-            0.0f32
-        );
-        assert_ne!(
-            test_block.block_io.output_buffer[0].axons[38].potential,
-            0.0f32
-        );
-        assert_ne!(
-            test_block.block_io.output_buffer[0].axons[80].potential,
-            0.0f32
-        );
-
-        // check random other ones, that they have not input
-        assert_eq!(test_block.neurons[1].input, 0.0f32);
-        assert_eq!(test_block.neurons[127].input, 0.0f32);
-        assert_eq!(test_block.neurons[10].input, 0.0f32);
-
-        // set test-deltas
-        test_block.block_io.output_buffer[0].axons[42].delta = 0.5f32;
-        test_block.block_io.output_buffer[0].axons[84].delta = 0.5f32;
-        test_block.block_io.output_buffer[0].axons[126].delta = 0.5f32;
-        test_block.block_io.output_buffer[0].axons[40].delta = 0.5f32;
-        test_block.block_io.output_buffer[0].axons[82].delta = 0.5f32;
-        test_block.block_io.output_buffer[0].axons[124].delta = 0.5f32;
-        test_block.block_io.output_buffer[0].axons[38].delta = 0.5f32;
-        test_block.block_io.output_buffer[0].axons[80].delta = 0.5f32;
-
-        let _ = test_block.backpropagate(cycle_number);
-
-        // check that delta of the source-axon was modified
-        assert_ne!(test_block.block_io.input_buffer[0].axons[0].delta, 0.0f32);
-        // println!("{}", test_block.input_buffer[0].axons[0].delta);
-
-        // check that all target-axons are reseted
-        assert_eq!(test_block.block_io.output_buffer[0].axons[42].delta, 0.0f32);
-        assert_eq!(test_block.block_io.output_buffer[0].axons[84].delta, 0.0f32);
-        assert_eq!(
-            test_block.block_io.output_buffer[0].axons[126].delta,
-            0.0f32
-        );
-        assert_eq!(test_block.block_io.output_buffer[0].axons[40].delta, 0.0f32);
-        assert_eq!(test_block.block_io.output_buffer[0].axons[82].delta, 0.0f32);
-        assert_eq!(
-            test_block.block_io.output_buffer[0].axons[124].delta,
-            0.0f32
-        );
-        assert_eq!(test_block.block_io.output_buffer[0].axons[38].delta, 0.0f32);
-        assert_eq!(test_block.block_io.output_buffer[0].axons[80].delta, 0.0f32);
-    }
-}
+// // Copyright 2022 Tobias Anker <tobias.anker@kitsunemimi.moe>
+
+// // Licensed under the Apache License, Version 2.0 (the "License");
+// // you may not use this file except in compliance with the License.
+// // You may obtain a copy of the License at
+
+// //     http://www.apache.org/licenses/LICENSE-2.0
+
+// // Unless required by applicable law or agreed to in writing, software
+// // distributed under the License is distributed on an "AS IS" BASIS,
+// // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// // See the License for the specific language governing permissions and
+// // limitations under the License.
+
+// use rand::Rng;
+// use std::sync::{Arc, Mutex};
+// use uuid::Uuid;
+
+// use ainari_common::constants::*;
+// use ainari_common::enums::*;
+// use ainari_common::error::AinariError;
+
+// use crate::core::processing::finish_counter::FinishCounter;
+
+// use super::axons::*;
+// use super::block_io::*;
+// use super::block_trait::*;
+
+// use super::super::processing::worker_queue::*;
+
+// // ==================================================================================================
+
+// #[derive(Debug, Clone, Copy)]
+// pub struct Synapse {
+//     pub weight: f32,
+//     pub upper: f32,
+//     pub lower: f32,
+//     pub layer: u8,
+
+//     pub active_counter: u8,
+//     pub source_axon: u8,
+
+//     pub active_counter_top: u8,
+//     pub active_counter_lower: u8,
+//     pub active_counter_upper: u8,
+// }
+
+// impl Synapse {
+//     pub fn default() -> Self {
+//         Synapse {
+//             weight: rand::rng().random_range(-0.5..=0.5),
+
+//             active_counter: 0,
+//             source_axon: UNINIT_STATE_8,
+
+//             upper: 2.0f32,
+//             lower: 0.0f32,
+//             layer: 0,
+
+//             active_counter_top: 0,
+//             active_counter_lower: 0,
+//             active_counter_upper: 0,
+//         }
+//     }
+// }
+
+// // ==================================================================================================
+
+// #[derive(Debug, Clone, Copy)]
+// pub struct Neuron {
+//     pub input: f32,
+//     // pub refraction_time: u8,
+// }
+
+// impl Neuron {
+//     #[allow(dead_code)]
+//     pub fn default() -> Self {
+//         Neuron {
+//             input: 0.0f32,
+//             // refraction_time: 0,
+//         }
+//     }
+// }
+
+// // ==================================================================================================
+
+// #[derive(Debug, Clone)]
+// pub struct NewCoreBlock {
+//     pub uuid: Uuid,
+//     pub hexagon_uuid: Uuid,
+//     pub cluster_uuid: Uuid,
+
+//     // HINT (kitsudaiki): this has to be a Box instead of a static array to avoid a stack-overflow, because the object is too big
+//     pub synapses: Box<[Synapse]>,
+//     pub buffer: [Synapse; BLOCK_DIM * 3],
+//     pub neurons: [Neuron; BLOCK_DIM * 3],
+//     pub fill_size: [u8; BLOCK_DIM * 3],
+
+//     pub synapse_counter: u64,
+
+//     pub block_io: BlockIoBuffer,
+// }
+
+// impl NewCoreBlock {
+//     #[allow(dead_code)]
+//     pub fn new(hexagon_uuid: &Uuid, cluster_uuid: &Uuid) -> Self {
+//         // internal visilization of the blocks:
+//         //
+//         // +---+ +---+ +---+
+//         // | 1 | | 3 | | 5 |
+//         // +---+ +---+ +---+
+//         // | 0 | | 2 | | 4 |
+//         // +---+ +---+ +---+
+//         //
+//         let capacity = BLOCK_DIM * 2 * BLOCK_DIM * 3;
+//         let mut vec = Vec::with_capacity(capacity);
+//         for _ in 0..capacity {
+//             vec.push(Synapse::default());
+//         }
+
+//         // set initial state
+//         let mut counter = 0_usize;
+//         let mut fill_size = std::array::from_fn(|_| 0u8);
+//         for (x_offset, fill_size) in fill_size.iter_mut().enumerate().take(BLOCK_DIM) {
+//             *fill_size = 2;
+//             for y_offset in 0..(*fill_size as usize) {
+//                 let synapse_pos = (x_offset * 2 * BLOCK_DIM) + y_offset;
+//                 let synapse = &mut vec[synapse_pos];
+//                 synapse.source_axon = counter as u8;
+//                 synapse.lower = 0.0f32;
+//                 synapse.upper = 2.0f32;
+//                 synapse.active_counter = 255;
+//                 counter += 1;
+//             }
+//         }
+
+//         let mut block = NewCoreBlock {
+//             uuid: Uuid::new_v4(),
+//             hexagon_uuid: *hexagon_uuid,
+//             cluster_uuid: *cluster_uuid,
+
+//             block_io: BlockIoBuffer::default(),
+
+//             synapses: vec.into_boxed_slice(),
+//             buffer: std::array::from_fn(|_| Synapse::default()),
+//             neurons: std::array::from_fn(|_| Neuron::default()),
+//             fill_size,
+
+//             // pre-initialized number of synapses, one for each possible input-axon
+//             synapse_counter: 256,
+//         };
+
+//         block.block_io.output_buffer.push(AxonSection::default());
+//         block.block_io.input_buffer.push(AxonSection::default());
+//         block.block_io.input_buffer.push(AxonSection::default());
+//         block.block_io.inputs_in_use = 0;
+
+//         block
+//     }
+
+//     fn handle_buffer(&mut self) {
+//         for x_offset in 0..(self.block_io.output_buffer.len() * BLOCK_DIM) {
+//             if self.buffer[x_offset].source_axon != UNINIT_STATE_8 {
+//                 let current_fill_size = self.fill_size[x_offset];
+
+//                 if current_fill_size < ((2 * BLOCK_DIM) - 2) as u8 {
+//                     let synapse_offset = (x_offset * 2 * BLOCK_DIM) + current_fill_size as usize;
+//                     self.synapses[synapse_offset] = self.buffer[x_offset];
+//                     self.buffer[x_offset] = Synapse::default();
+
+//                     self.fill_size[x_offset] += 1;
+//                     self.synapse_counter += 1;
+//                 }
+//             }
+//         }
+//     }
+
+//     fn check_and_resize_block(&mut self) {
+//         // resize block in case it is filled enough
+//         if self.block_io.output_buffer.len() == 1
+//             && self.synapse_counter as f32 >= ((BLOCK_DIM * BLOCK_DIM) as f32 * 0.9f32)
+//         {
+//             self.block_io.output_buffer.push(AxonSection::default());
+//         }
+//         if self.block_io.output_buffer.len() == 2
+//             && self.synapse_counter as f32 >= ((BLOCK_DIM * BLOCK_DIM * 2) as f32 * 0.9f32)
+//         {
+//             self.block_io.output_buffer.push(AxonSection::default());
+//         }
+//     }
+
+//     fn apply_output(&mut self) {
+//         let mut counter = 0;
+//         for o in 0..self.block_io.output_buffer.len() {
+//             for i in 0..BLOCK_DIM {
+//                 self.block_io.output_buffer[o].axons[i].potential = self.neurons[counter].input;
+//                 counter += 1;
+//             }
+//         }
+//     }
+// }
+
+// // ==================================================================================================
+
+// impl Block for NewCoreBlock {
+//     fn train(
+//         &mut self,
+//         place_offset: usize,
+//         _: Arc<Mutex<dyn Block>>,
+//         cycle_number: u64,
+//     ) -> Result<Option<Arc<Mutex<FinishCounter>>>, AinariError> {
+//         self.handle_buffer();
+//         self.check_and_resize_block();
+
+//         // // debug-output
+//         // println!("core-buffer-axons: ");
+//         // for axon in self.input_buffer[0].axons.iter_mut() {
+//         //     print!("{} ", axon.potential);
+//         // }
+//         // println!(" ");
+
+//         let number_of_output_blocks = self.block_io.output_buffer.len();
+//         for x_offset in 0..(number_of_output_blocks * BLOCK_DIM) {
+//             let neuron = &mut self.neurons[x_offset];
+//             neuron.input = 0.0f32;
+
+//             for y_offset in 0..(self.fill_size[x_offset] as usize) {
+//                 // get values
+//                 let synapse_pos = (x_offset * 2 * BLOCK_DIM) + y_offset;
+//                 let synapse = &mut self.synapses[synapse_pos];
+//                 let source_potential = self.block_io.input_buffer
+//                     [synapse.source_axon as usize / BLOCK_DIM]
+//                     .axons[synapse.source_axon as usize % BLOCK_DIM]
+//                     .potential;
+//                 if source_potential <= 0.0f32 {
+//                     continue;
+//                 }
+//                 let third = (synapse.upper - synapse.lower) / 3.0f32;
+
+//                 // update current synapse
+//                 let update = (source_potential > synapse.lower) as u8;
+//                 neuron.input += synapse.weight * update as f32;
+//                 synapse.active_counter += update * (synapse.active_counter < 254) as u8;
+
+//                 if synapse.layer < 6 {
+//                     // handling first layer split
+//                     if synapse.layer == 0
+//                         && synapse.active_counter_top == 0
+//                         && source_potential > synapse.upper
+//                     {
+//                         let mut new_synapse = Synapse::default();
+//                         new_synapse.source_axon = synapse.source_axon;
+//                         new_synapse.upper =
+//                             ((synapse.upper - new_synapse.lower) * 2.0f32) + synapse.upper;
+//                         new_synapse.lower = synapse.upper;
+//                         new_synapse.layer = 0;
+//                         let pos = (place_offset + x_offset) % (number_of_output_blocks * BLOCK_DIM);
+//                         if self.buffer[pos].source_axon == UNINIT_STATE_8 {
+//                             self.buffer[pos] = new_synapse;
+//                             synapse.active_counter_top = 1;
+//                         }
+//                     }
+
+//                     // handle upper split
+//                     if synapse.active_counter_upper == 0
+//                         && source_potential <= synapse.upper
+//                         && source_potential > synapse.upper - third
+//                     {
+//                         let mut new_synapse = Synapse::default();
+//                         new_synapse.source_axon = synapse.source_axon;
+//                         new_synapse.upper = synapse.upper;
+//                         new_synapse.lower = synapse.upper - third;
+//                         new_synapse.layer = synapse.layer + 1;
+//                         let pos = (place_offset + x_offset) % (number_of_output_blocks * BLOCK_DIM);
+//                         if self.buffer[pos].source_axon == UNINIT_STATE_8 {
+//                             self.buffer[pos] = new_synapse;
+//                             synapse.active_counter_upper = 1;
+//                         }
+//                     }
+
+//                     // handle lower split
+//                     if synapse.active_counter_lower == 0
+//                         && source_potential > synapse.lower
+//                         && source_potential <= synapse.lower + third
+//                     {
+//                         let mut new_synapse = Synapse::default();
+//                         new_synapse.source_axon = synapse.source_axon;
+//                         new_synapse.upper = synapse.lower + third;
+//                         new_synapse.lower = synapse.lower;
+//                         new_synapse.layer = synapse.layer + 1;
+//                         let pos = (place_offset + x_offset) % (number_of_output_blocks * BLOCK_DIM);
+//                         if self.buffer[pos].source_axon == UNINIT_STATE_8 {
+//                             self.buffer[pos] = new_synapse;
+//                             synapse.active_counter_lower = 1;
+//                         }
+//                     }
+//                 }
+//             }
+
+//             // TODO: handle refraction-type and node-cooldown of neuron
+//         }
+
+//         self.apply_output();
+//         connect_outputs(
+//             &mut self.block_io,
+//             &self.cluster_uuid,
+//             &self.hexagon_uuid,
+//             &self.uuid,
+//         )?;
+//         send_forward(&self.block_io, WorkerTaskType::Train, cycle_number);
+
+//         Ok(None)
+//     }
+
+//     fn process(
+//         &mut self,
+//         cycle_number: u64,
+//     ) -> Result<Option<Arc<Mutex<FinishCounter>>>, AinariError> {
+//         // // debug-output
+//         // println!("core-buffer-axons: ");
+//         // for axon in self.input_buffer[0].axons.iter_mut() {
+//         //     print!("{} ", axon.potential);
+//         // }
+//         // println!(" ");
+
+//         let number_of_output_blocks = self.block_io.output_buffer.len();
+//         for x_offset in 0..(number_of_output_blocks * BLOCK_DIM) {
+//             let neuron = &mut self.neurons[x_offset];
+//             neuron.input = 0.0f32;
+
+//             for y_offset in 0..(self.fill_size[x_offset] as usize) {
+//                 // get values
+//                 let synapse_pos = (x_offset * 2 * BLOCK_DIM) + y_offset;
+//                 let synapse = &mut self.synapses[synapse_pos];
+//                 let source_weight = self.block_io.input_buffer
+//                     [synapse.source_axon as usize / BLOCK_DIM]
+//                     .axons[synapse.source_axon as usize % BLOCK_DIM]
+//                     .potential;
+
+//                 // update current synapse
+//                 let update = (source_weight > synapse.lower) as u8;
+//                 neuron.input += synapse.weight * update as f32;
+//                 synapse.active_counter += update * (synapse.active_counter < 254) as u8;
+//             }
+
+//             // TODO: handle refraction-type and node-cooldown of neuron
+//         }
+//         self.apply_output();
+//         send_forward(&self.block_io, WorkerTaskType::Process, cycle_number);
+
+//         Ok(None)
+//     }
+
+//     fn backpropagate(
+//         &mut self,
+//         cycle_number: u64,
+//     ) -> Result<Option<Arc<Mutex<FinishCounter>>>, AinariError> {
+//         let train_value = 0.1f32;
+
+//         let number_of_output_blocks = self.block_io.output_buffer.len();
+//         for x_offset in 0..(number_of_output_blocks * BLOCK_DIM) {
+//             let target_axon =
+//                 &mut self.block_io.output_buffer[x_offset / BLOCK_DIM].axons[x_offset % BLOCK_DIM];
+//             if target_axon.delta == 0.0f32 {
+//                 continue;
+//             }
+
+//             for y_offset in 0..(self.fill_size[x_offset] as usize) {
+//                 let synapse = &mut self.synapses[(x_offset * 2 * BLOCK_DIM) + y_offset];
+//                 let source_axon = &mut self.block_io.input_buffer
+//                     [synapse.source_axon as usize / BLOCK_DIM]
+//                     .axons[synapse.source_axon as usize % BLOCK_DIM];
+//                 let update = (source_axon.potential > synapse.lower) as u8;
+//                 let delta = target_axon.delta * synapse.weight * update as f32;
+//                 synapse.weight -= train_value * target_axon.delta;
+//                 source_axon.delta += delta;
+//             }
+
+//             target_axon.delta = 0.0f32;
+//         }
+
+//         send_backward(&self.block_io, cycle_number);
+
+//         Ok(None)
+//     }
+
+//     fn get_free_input(&mut self, axon_section: &mut AxonSection) -> bool {
+//         if self.block_io.inputs_in_use == 0 {
+//             axon_section.target_block_uuid = self.uuid;
+//             axon_section.target_hexagon_uuid = self.hexagon_uuid;
+//             axon_section.target_pos = 0;
+//             self.block_io.input_buffer[0] = axon_section.clone();
+//             self.block_io.inputs_in_use = 1;
+//             return true;
+//         }
+
+//         if self.block_io.inputs_in_use == 1 {
+//             axon_section.target_block_uuid = self.uuid;
+//             axon_section.target_hexagon_uuid = self.hexagon_uuid;
+//             axon_section.target_pos = 1;
+//             self.block_io.input_buffer[1] = axon_section.clone();
+//             self.block_io.inputs_in_use = 2;
+//             return true;
+//         }
+
+//         false
+//     }
+
+//     fn get_uuid(&self) -> Uuid {
+//         self.uuid
+//     }
+
+//     fn get_hexagon_uud(&self) -> Uuid {
+//         self.hexagon_uuid
+//     }
+//     fn get_cluster_uud(&self) -> Uuid {
+//         self.cluster_uuid
+//     }
+
+//     fn get_block_io(&mut self) -> &mut BlockIoBuffer {
+//         &mut self.block_io
+//     }
+
+//     fn get_type(&self) -> ObjectType {
+//         ObjectType::Unknown
+//     }
+
+//     fn set_cluster_uuid(&mut self, new_cluster_uuid: &Uuid) {
+//         self.cluster_uuid = *new_cluster_uuid;
+//     }
+
+//     fn serailize(&self) -> Vec<u8> {
+//         Vec::new()
+//     }
+// }
+
+// #[cfg(test)]
+// mod tests {
+//     use uuid::Uuid;
+
+//     use ainari_common::constants::*;
+
+//     use super::*;
+
+//     #[test]
+//     fn test_process() {
+//         let cluster_uuid = Uuid::new_v4();
+//         let hexagon_uuid = Uuid::new_v4();
+//         let mut test_block = NewCoreBlock::new(&hexagon_uuid, &cluster_uuid);
+//         test_block.buffer[1].source_axon = 42;
+//         let own: Arc<Mutex<dyn Block>> = Arc::new(Mutex::new(test_block.clone()));
+//         let cycle_number = 0;
+
+//         let mut test_axon = AxonSection::default();
+//         test_axon.axons[0].potential = 10.0f32;
+
+//         test_block.block_io.input_buffer[0] = test_axon;
+
+//         let _ = test_block.train(42, Arc::clone(&own), cycle_number);
+
+//         // check if buffer-processing works correctly
+//         assert_eq!(test_block.fill_size[1], 3);
+//         assert_eq!(test_block.buffer[1].source_axon, UNINIT_STATE_8);
+//         assert_eq!(test_block.synapses[2 * BLOCK_DIM + 2].source_axon, 42);
+//         assert_eq!(test_block.synapse_counter, 257);
+
+//         // run processing in order to create new synapses
+//         let _ = test_block.train(42, Arc::clone(&own), cycle_number);
+//         assert_eq!(test_block.synapse_counter, 258);
+//         let _ = test_block.train(42, Arc::clone(&own), cycle_number);
+//         assert_eq!(test_block.synapse_counter, 259);
+//         let _ = test_block.train(42, Arc::clone(&own), cycle_number);
+//         assert_eq!(test_block.synapse_counter, 260);
+//         let _ = test_block.train(42, Arc::clone(&own), cycle_number);
+//         assert_eq!(test_block.synapse_counter, 261);
+//         let _ = test_block.train(42, Arc::clone(&own), cycle_number);
+//         assert_eq!(test_block.synapse_counter, 262);
+//         let _ = test_block.train(42, Arc::clone(&own), cycle_number);
+//         assert_eq!(test_block.synapse_counter, 263);
+//         let _ = test_block.train(42, Arc::clone(&own), cycle_number);
+//         assert_eq!(test_block.synapse_counter, 264);
+//         let _ = test_block.train(42, Arc::clone(&own), cycle_number);
+//         assert_eq!(test_block.synapse_counter, 265);
+//         // after depth = 8, nothing more will be added
+//         let _ = test_block.train(42, Arc::clone(&own), cycle_number);
+//         assert_eq!(test_block.synapse_counter, 265);
+
+//         // check fill-size
+//         assert_eq!(test_block.fill_size[1], 3);
+//         assert_eq!(test_block.fill_size[42], 3);
+//         assert_eq!(test_block.fill_size[84], 3);
+//         assert_eq!(test_block.fill_size[126], 3);
+//         assert_eq!(test_block.fill_size[40], 3);
+//         assert_eq!(test_block.fill_size[82], 3);
+//         assert_eq!(test_block.fill_size[124], 3);
+//         assert_eq!(test_block.fill_size[38], 3);
+//         assert_eq!(test_block.fill_size[80], 3);
+//         assert_eq!(test_block.fill_size[122], 2);
+
+//         // check that affected neurons have input
+//         assert_ne!(test_block.neurons[84].input, 0.0f32);
+//         assert_ne!(test_block.neurons[126].input, 0.0f32);
+//         assert_ne!(test_block.neurons[40].input, 0.0f32);
+//         assert_ne!(test_block.neurons[82].input, 0.0f32);
+//         assert_ne!(test_block.neurons[124].input, 0.0f32);
+//         assert_ne!(test_block.neurons[38].input, 0.0f32);
+//         assert_ne!(test_block.neurons[80].input, 0.0f32);
+//         assert_ne!(
+//             test_block.block_io.output_buffer[0].axons[84].potential,
+//             0.0f32
+//         );
+//         assert_ne!(
+//             test_block.block_io.output_buffer[0].axons[126].potential,
+//             0.0f32
+//         );
+//         assert_ne!(
+//             test_block.block_io.output_buffer[0].axons[40].potential,
+//             0.0f32
+//         );
+//         assert_ne!(
+//             test_block.block_io.output_buffer[0].axons[82].potential,
+//             0.0f32
+//         );
+//         assert_ne!(
+//             test_block.block_io.output_buffer[0].axons[124].potential,
+//             0.0f32
+//         );
+//         assert_ne!(
+//             test_block.block_io.output_buffer[0].axons[38].potential,
+//             0.0f32
+//         );
+//         assert_ne!(
+//             test_block.block_io.output_buffer[0].axons[80].potential,
+//             0.0f32
+//         );
+
+//         // check random other ones, that they have not input
+//         assert_eq!(test_block.neurons[1].input, 0.0f32);
+//         assert_eq!(test_block.neurons[127].input, 0.0f32);
+//         assert_eq!(test_block.neurons[10].input, 0.0f32);
+
+//         // set test-deltas
+//         test_block.block_io.output_buffer[0].axons[42].delta = 0.5f32;
+//         test_block.block_io.output_buffer[0].axons[84].delta = 0.5f32;
+//         test_block.block_io.output_buffer[0].axons[126].delta = 0.5f32;
+//         test_block.block_io.output_buffer[0].axons[40].delta = 0.5f32;
+//         test_block.block_io.output_buffer[0].axons[82].delta = 0.5f32;
+//         test_block.block_io.output_buffer[0].axons[124].delta = 0.5f32;
+//         test_block.block_io.output_buffer[0].axons[38].delta = 0.5f32;
+//         test_block.block_io.output_buffer[0].axons[80].delta = 0.5f32;
+
+//         let _ = test_block.backpropagate(cycle_number);
+
+//         // check that delta of the source-axon was modified
+//         assert_ne!(test_block.block_io.input_buffer[0].axons[0].delta, 0.0f32);
+//         // println!("{}", test_block.input_buffer[0].axons[0].delta);
+
+//         // check that all target-axons are reseted
+//         assert_eq!(test_block.block_io.output_buffer[0].axons[42].delta, 0.0f32);
+//         assert_eq!(test_block.block_io.output_buffer[0].axons[84].delta, 0.0f32);
+//         assert_eq!(
+//             test_block.block_io.output_buffer[0].axons[126].delta,
+//             0.0f32
+//         );
+//         assert_eq!(test_block.block_io.output_buffer[0].axons[40].delta, 0.0f32);
+//         assert_eq!(test_block.block_io.output_buffer[0].axons[82].delta, 0.0f32);
+//         assert_eq!(
+//             test_block.block_io.output_buffer[0].axons[124].delta,
+//             0.0f32
+//         );
+//         assert_eq!(test_block.block_io.output_buffer[0].axons[38].delta, 0.0f32);
+//         assert_eq!(test_block.block_io.output_buffer[0].axons[80].delta, 0.0f32);
+//     }
+// }

--- a/src/binaries/hanami/src/core/blocks/output_block.rs
+++ b/src/binaries/hanami/src/core/blocks/output_block.rs
@@ -264,7 +264,7 @@ impl Block for OutputBlock {
             axon.delta *= axon.potential * (1.0f32 - axon.potential);
         }
 
-        send_backward(&self.block_io, cycle_number);
+        send_backward(&mut self.block_io, cycle_number);
 
         Ok(None)
     }
@@ -280,6 +280,18 @@ impl Block for OutputBlock {
         }
 
         false
+    }
+
+    fn finalize_train(&mut self, _: u64) -> Result<(), AinariError> {
+        Ok(())
+    }
+
+    fn finalize_process(&mut self, _: u64) -> Result<(), AinariError> {
+        Ok(())
+    }
+
+    fn finalize_backpropagate(&mut self, _: u64) -> Result<bool, AinariError> {
+        Ok(true)
     }
 
     fn get_uuid(&self) -> Uuid {

--- a/src/binaries/hanami/src/core/blocks/target_search.rs
+++ b/src/binaries/hanami/src/core/blocks/target_search.rs
@@ -13,6 +13,8 @@
 // limitations under the License.
 
 use rand::Rng;
+use rand::seq::IteratorRandom;
+use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 use uuid::Uuid;
 
@@ -32,24 +34,14 @@ struct TargetInformation {
     output_hexagon_name: String,
 }
 
-pub fn connect_to_target(axon_section: &mut AxonSection) -> Result<(), AinariError> {
+pub fn connect_to_new_target(axon_section: &mut AxonSection) -> Result<(), AinariError> {
     check_axon_setion(axon_section)?;
 
-    let target_information = get_target(axon_section)?;
+    let target_information = get_target_hexagon(axon_section)?;
 
     let source_block;
     let cluster_settings;
-
-    {
-        let mut cluster_handler = CLUSTER_HANDLER.write().unwrap();
-        let cluster_link = cluster_handler.get_cluster_mut(&axon_section.cluster_uuid)?;
-
-        // get target-hexagon from cluster
-        let mut binding = cluster_link.hexagon_data.write().unwrap();
-        binding
-            .entry(target_information.hexagon_uuid)
-            .or_insert_with(|| Arc::new(Mutex::new(HexagonData::new())));
-    }
+    let selected_block_option;
 
     {
         let cluster_handler = CLUSTER_HANDLER.read().unwrap();
@@ -74,15 +66,23 @@ pub fn connect_to_target(axon_section: &mut AxonSection) -> Result<(), AinariErr
             return Err(AinariError::InvalidInput(msg));
         };
 
-        // search for a block, which has a free slot
-        for block_mutex in target_hexagon_link.blocks.values() {
-            // ERROR: can hang here
-            let mut block = block_mutex.lock().unwrap();
-            if block.get_free_input(axon_section) {
-                axon_section.target_block = Some(block_mutex.clone());
-                axon_section.source_block = Some(source_block);
-                return Ok(());
+        match random_value(&target_hexagon_link.blocks) {
+            Some(value) => {
+                selected_block_option = Some(value.clone());
             }
+            None => {
+                selected_block_option = None;
+            }
+        }
+    }
+
+    // check if the reandome selected block is available
+    if let Some(selected_block_mutex) = selected_block_option {
+        let mut selected_block = selected_block_mutex.lock().unwrap();
+        if selected_block.get_free_input(axon_section) {
+            axon_section.target_block = Some(selected_block_mutex.clone());
+            axon_section.source_block = Some(source_block);
+            return Ok(());
         }
     }
 
@@ -126,6 +126,14 @@ pub fn connect_to_target(axon_section: &mut AxonSection) -> Result<(), AinariErr
     Err(AinariError::Error(msg))
 }
 
+fn random_value<K, V>(map: &HashMap<K, V>) -> Option<&V>
+where
+    K: std::hash::Hash + Eq,
+{
+    let mut rng = rand::rng();
+    map.values().choose(&mut rng)
+}
+
 fn check_axon_setion(axon_section: &mut AxonSection) -> Result<(), AinariError> {
     // pre-check
     if axon_section.cluster_uuid == Uuid::nil()
@@ -140,53 +148,51 @@ fn check_axon_setion(axon_section: &mut AxonSection) -> Result<(), AinariError> 
     Ok(())
 }
 
-fn get_target(axon_section: &mut AxonSection) -> Result<TargetInformation, AinariError> {
+fn get_target_hexagon(axon_section: &mut AxonSection) -> Result<TargetInformation, AinariError> {
     let mut cluster_handler = CLUSTER_HANDLER.write().unwrap();
     let mut target_information = TargetInformation::default();
     let cluster_link = cluster_handler.get_cluster_mut(&axon_section.cluster_uuid)?;
 
     // get the uuid of the target-hexagon
+    if let Some(source_hexagon_meta) = cluster_link
+        .cluster_meta
+        .hexagons
+        .get(&axon_section.source_hexagon_uuid)
     {
-        if let Some(source_hexagon_meta) = cluster_link
-            .cluster_meta
-            .hexagons
-            .get(&axon_section.source_hexagon_uuid)
-        {
-            let random_pos = rand::rng().random_range(0..NUMBER_OF_POSSIBLE_NEXT) as usize;
-            target_information.hexagon_uuid =
-                source_hexagon_meta.possible_hexagon_target_ids[random_pos];
-        } else {
-            let msg = format!(
-                "Hexagon with uuid '{}' not found in cluster-meta.",
-                axon_section.source_hexagon_uuid
-            );
-            return Err(AinariError::InvalidInput(msg));
-        };
+        let random_pos = rand::rng().random_range(0..NUMBER_OF_POSSIBLE_NEXT) as usize;
+        target_information.hexagon_uuid =
+            source_hexagon_meta.possible_hexagon_target_ids[random_pos];
+    } else {
+        let msg = format!(
+            "Hexagon with uuid '{}' not found in cluster-meta.",
+            axon_section.source_hexagon_uuid
+        );
+        return Err(AinariError::InvalidInput(msg));
+    };
 
-        if let Some(target_hexagon_meta) = cluster_link
-            .cluster_meta
-            .hexagons
-            .get(&target_information.hexagon_uuid)
-        {
-            target_information.is_output = target_hexagon_meta.is_output;
-            target_information.output_hexagon_name = target_hexagon_meta.name.clone();
+    if let Some(target_hexagon_meta) = cluster_link
+        .cluster_meta
+        .hexagons
+        .get(&target_information.hexagon_uuid)
+    {
+        target_information.is_output = target_hexagon_meta.is_output;
+        target_information.output_hexagon_name = target_hexagon_meta.name.clone();
 
-            // input-hexagons are not allowed to be a target
-            if target_hexagon_meta.is_input {
-                let msg = format!(
-                    "Hexagon with uuid '{}' is input-hexagon and can not be used as output.",
-                    target_information.hexagon_uuid
-                );
-                return Err(AinariError::InvalidInput(msg));
-            }
-        } else {
+        // input-hexagons are not allowed to be a target
+        if target_hexagon_meta.is_input {
             let msg = format!(
-                "Hexagon with uuid '{}' not found in cluster-meta.",
+                "Hexagon with uuid '{}' is input-hexagon and can not be used as output.",
                 target_information.hexagon_uuid
             );
             return Err(AinariError::InvalidInput(msg));
-        };
-    }
+        }
+    } else {
+        let msg = format!(
+            "Hexagon with uuid '{}' not found in cluster-meta.",
+            target_information.hexagon_uuid
+        );
+        return Err(AinariError::InvalidInput(msg));
+    };
 
     // add hexagon if necessary
     let mut hexagon_data = cluster_link.hexagon_data.write().unwrap();
@@ -295,7 +301,7 @@ mod tests {
         test_section.cluster_uuid = core_block.cluster_uuid;
         test_section.source_pos = 0;
 
-        match connect_to_target(&mut test_section) {
+        match connect_to_new_target(&mut test_section) {
             Ok(()) => {}
             Err(e) => {
                 println!("{e}");

--- a/src/binaries/hanami/src/core/processing/tasks.rs
+++ b/src/binaries/hanami/src/core/processing/tasks.rs
@@ -195,13 +195,6 @@ impl Task {
 
         // update and check cycle- and epoch-counter
         self.meta.number_of_finished_cycles += 1;
-        if self.meta.number_of_finished_cycles == 1076 {
-            println!("poi");
-        }
-        println!(
-            "self.meta.number_of_finished_cycles: {}",
-            self.meta.number_of_finished_cycles
-        );
         if self.meta.number_of_finished_cycles == self.meta.number_of_cycles {
             self.meta.number_of_finished_epochs += 1;
             if self.meta.number_of_finished_epochs == self.meta.number_of_epochs {

--- a/src/binaries/hanami/src/core/processing/worker_thread.rs
+++ b/src/binaries/hanami/src/core/processing/worker_thread.rs
@@ -31,27 +31,59 @@ pub struct WorkerThread {
     pub running: Arc<AtomicBool>,
 }
 
+fn finalize_task(worker_task: &WorkerTask) -> Result<(), AinariError> {
+    for _ in 0..1000 {
+        let mut block = worker_task.block.lock().unwrap();
+        let success = match worker_task.task_type {
+            WorkerTaskType::Train => {
+                block.finalize_train(worker_task.cycle_number)?;
+                true
+            }
+            WorkerTaskType::Process => {
+                block.finalize_process(worker_task.cycle_number)?;
+                true
+            }
+            WorkerTaskType::Backpropagate => {
+                block.finalize_backpropagate(worker_task.cycle_number)?
+            }
+        };
+        drop(block);
+
+        if success {
+            return Ok(());
+        }
+
+        thread::sleep(Duration::from_millis(1));
+    }
+
+    log::error!("Timeout while try to backpropagate");
+    Ok(())
+}
+
 fn process_task(worker_task: &WorkerTask) -> Result<(), AinariError> {
     #[allow(clippy::needless_late_init)]
     let finish_counter_option;
-    let mut block = worker_task.block.lock().unwrap();
-    match worker_task.task_type {
-        WorkerTaskType::Train => {
-            let place_offset = rand::rng().random_range(0..BLOCK_DIM);
-            finish_counter_option = block.train(
-                place_offset,
-                Arc::clone(&worker_task.block),
-                worker_task.cycle_number,
-            )?;
-        }
-        WorkerTaskType::Process => {
-            finish_counter_option = block.process(worker_task.cycle_number)?;
-        }
-        WorkerTaskType::Backpropagate => {
-            finish_counter_option = block.backpropagate(worker_task.cycle_number)?;
+    {
+        let mut block = worker_task.block.lock().unwrap();
+        match worker_task.task_type {
+            WorkerTaskType::Train => {
+                let place_offset = rand::rng().random_range(0..BLOCK_DIM);
+                finish_counter_option = block.train(
+                    place_offset,
+                    Arc::clone(&worker_task.block),
+                    worker_task.cycle_number,
+                )?;
+            }
+            WorkerTaskType::Process => {
+                finish_counter_option = block.process(worker_task.cycle_number)?;
+            }
+            WorkerTaskType::Backpropagate => {
+                finish_counter_option = block.backpropagate(worker_task.cycle_number)?;
+            }
         }
     }
-    drop(block);
+
+    finalize_task(worker_task)?;
 
     // register the backpropagation for the input-bock to update the finish-counter
     // HINT (kitsudaiki): This can not be done within the blocks, because it would result in a dead-lock


### PR DESCRIPTION

## Pull Request

### Description
In bigger clusters with multiple core-hexagons,
there were deadlocks between the core-blocks of these possible, in case that the backpropagation started before all paths reached the output. The problem
was solves by some reordering of locks and replacing the lock in backpropagation, for transfering axons backward, by a try_lock with retry-loop.

<!-- A concise description of the content of the pull-request -->

### Related Issues

- #647
<!-- In context of which issues the changes of this pull request were created. -->

### How it was tested?

- sdk-api-test with more hexagons
<!-- What parts and how they were tested -->
