### PR TITLE
revert(#651): revert border change

### DIFF
--- a/src/libs/rust/ainari_common/src/constants.rs
+++ b/src/libs/rust/ainari_common/src/constants.rs
@@ -29,7 +29,7 @@ pub const POTENTIAL_BORDER: f32 = 0.00001f32;
 pub const CORE_TRAIN_VALUE: f32 = 0.1f32;
 pub const OUTPUT_TRAIN_VALUE: f32 = 0.05f32;
 pub const ABSOLUTE_CREATE_BORDER: f32 = 0.05f32;
-pub const RELATIVE_CREATE_BORDER: f32 = 0.33f32;
+pub const RELATIVE_CREATE_BORDER: f32 = 0.05f32;
 
 // processing
 pub const NUMBER_OF_RESERVED_THREADS: usize = 2;


### PR DESCRIPTION


## Pull Request

### Description
The change in the border-value for update synapses was reverted, because it turned out to make the
measurement-test worse, even if it has some performance improvement.
<!-- A concise description of the content of the pull-request -->

### Related Issues

- #651 
<!-- In context of which issues the changes of this pull request were created. -->

### How it was tested?

- ci-pipeline
- measurement-test
<!-- What parts and how they were tested -->
