### PR TITLE
fix(#664): fix arm64 build in CI

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -652,7 +652,7 @@ jobs:
       matrix:
         platform:
           - linux/amd64
-          # - linux/arm64
+          - linux/arm64
     steps:
       -
         name: Prepare
@@ -786,7 +786,7 @@ jobs:
       matrix:
         platform:
           - linux/amd64
-          # - linux/arm64
+          - linux/arm64
     steps:
       -
         name: Prepare


### PR DESCRIPTION


## Pull Request

### Description
Missed to enable the arm64 build in the ci again,
which was fixed now.
<!-- A concise description of the content of the pull-request -->

### Related Issues

- #664 
<!-- In context of which issues the changes of this pull request were created. -->

### How it was tested?

(no tests)
<!-- What parts and how they were tested -->
