### PR TITLE
fix(#676): fix accuracy problem in bigger tests

### DIFF
--- a/src/binaries/hanami/src/core/blocks/core_block.rs
+++ b/src/binaries/hanami/src/core/blocks/core_block.rs
@@ -338,9 +338,10 @@ fn train_section(
         }
 
         if connection.next != UNINIT_STATE_16 {
+            let used_potential = (axon.potential - connection.lower_bound) - potential;
             let next_connection = &mut connections[connection.next as usize];
-            if next_connection.lower_bound < potential {
-                next_connection.lower_bound = potential;
+            if next_connection.lower_bound < used_potential {
+                next_connection.lower_bound = used_potential;
             }
         }
     }


### PR DESCRIPTION


## Pull Request

### Description

In slightly bigger tests with some weather data
the output was quite broken. After investigation
it appeared, that the handling of the overflow of
potential to the next section was not calculated
correctly, which resulted in the cut in the potential in case one section is not enough. The calculation was fixed, which resulted in quite good results
in the first tests so far.
<!-- A concise description of the content of the pull-request -->

### Related Issues

- #676 
<!-- In context of which issues the changes of this pull request were created. -->

### How it was tested?

- tests with some weather data
- sdk-api-test
<!-- What parts and how they were tested -->
