### PR TITLE
build(#681): reduce size of build result

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,3 +7,14 @@ members = [
     "src/libs/rust/ainari_api", 
     "src/libs/rust/ainari_hardware", 
     "src/binaries/torii"]
+
+[profile.dev]
+opt-level = 0
+debug = true
+overflow-checks = true
+
+[profile.release]
+opt-level = 3
+lto = "fat"
+codegen-units = 1
+strip = true

--- a/src/binaries/hanami/Cargo.toml
+++ b/src/binaries/hanami/Cargo.toml
@@ -51,11 +51,3 @@ static_assertions = "1.1.0"
 
 [dev-dependencies]
 serial_test = "3"
-
-[profile.dev]
-opt-level = 0
-debug = true
-overflow-checks = true
-
-[profile.release]
-opt-level = 3

--- a/src/binaries/torii/Cargo.toml
+++ b/src/binaries/torii/Cargo.toml
@@ -42,11 +42,3 @@ uuid = { version = "1.18.0", features = ["serde", "fast-rng", "v4"] }
 
 [dev-dependencies]
 serial_test = "3"
-
-[profile.dev]
-opt-level = 0
-debug = true
-overflow-checks = true
-
-[profile.release]
-opt-level = 3


### PR DESCRIPTION

## Pull Request

### Description

Updated the Cargo.toml in order to reduce the size of the resulting binaries in exchange for a bit
longer compile time.

<!-- A concise description of the content of the pull-request -->

### Related Issues

- #681 
<!-- In context of which issues the changes of this pull request were created. -->

### How it was tested?

- build locally with old and new config and checked size of the binaries in the target directory
- sdk-api-test to check speed
<!-- What parts and how they were tested -->
