### PR TITLE
fix: fix docker-build

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -661,7 +661,7 @@ jobs:
           - { component: "miko", platform: "linux/amd64", regitry: "kitsudaiki/miko" }
           - { component: "miko", platform: "linux/arm64", regitry: "kitsudaiki/miko" }
           - { component: "bento", platform: "linux/amd64", regitry: "kitsudaiki/bento" }
-          - { component: "bento", platform: "linux/arm64", regitry: "$kitsudaiki/bento" }
+          - { component: "bento", platform: "linux/arm64", regitry: "kitsudaiki/bento" }
     steps:
       -
         name: Prepare


### PR DESCRIPTION


## Pull Request

### Description

Because of a copy-paste mistake in the ci-pipeline the arm64-version of bento can not be build. This
was fixed by this commit.
<!-- A concise description of the content of the pull-request -->

### Related Issues

- (no related issue)
<!-- In context of which issues the changes of this pull request were created. -->

### How it was tested?

<!-- What parts and how they were tested -->
