### PR TITLE
fix(#709): fix endpoints in kubernetes-setup

### DIFF
--- a/deploy/k8s/ainari/templates/miko/miko-config.yaml
+++ b/deploy/k8s/ainari/templates/miko/miko-config.yaml
@@ -21,14 +21,14 @@ data:
     file_path = "/etc/ainari/miko/miko_db"
 
     [endpoints.hanami]
-    public_address = "https://hanami-tls-service.default.svc.cluster.local"
-    public_port = 8443
+    public_address = "https://local-hanami"
+    public_port = 443
     internal_address = "https://hanami-tls-service.default.svc.cluster.local"
     internal_port = 8443
 
     [endpoints.bento]
-    public_address = "https://bento-tls-service.default.svc.cluster.local"
-    public_port = 8443
+    public_address = "https://local-bento"
+    public_port = 443
     internal_address = "https://bento-tls-service.default.svc.cluster.local"
     internal_port = 8443
 

--- a/src/binaries/miko/src/api/http_endpoints/endpoints/get_endpoints_v1_0.rs
+++ b/src/binaries/miko/src/api/http_endpoints/endpoints/get_endpoints_v1_0.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use actix_web::web::Json;
-use ainari_api_structs::endpoints_structs::HanamiEndpontsResp;
+use ainari_api_structs::endpoints_structs::EndpointField;
 use apistos::api_operation;
 
 use crate::config;
@@ -33,13 +33,17 @@ pub async fn get_endpoints(_: UserContext) -> Result<Json<EndpontsResp>, ErrorRe
     let enpoint_config = &config::CONFIG.endpoints;
 
     let response = EndpontsResp {
-        hanami: HanamiEndpontsResp {
+        hanami: EndpointField {
             public_address: enpoint_config.hanami.public_address.clone(),
             public_port: enpoint_config.hanami.public_port,
+            internal_address: enpoint_config.hanami.internal_address.clone(),
+            internal_port: enpoint_config.hanami.internal_port,
         },
-        bento: BentoEndpontsResp {
+        bento: EndpointField {
             public_address: enpoint_config.bento.public_address.clone(),
             public_port: enpoint_config.bento.public_port,
+            internal_address: enpoint_config.bento.internal_address.clone(),
+            internal_port: enpoint_config.bento.internal_port,
         },
     };
 

--- a/src/libs/rust/ainari_api_structs/src/endpoints_structs.rs
+++ b/src/libs/rust/ainari_api_structs/src/endpoints_structs.rs
@@ -17,19 +17,15 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Debug, Clone, JsonSchema, ApiComponent)]
-pub struct HanamiEndpontsResp {
+pub struct EndpointField {
     pub public_address: String,
     pub public_port: u16,
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone, JsonSchema, ApiComponent)]
-pub struct BentoEndpontsResp {
-    pub public_address: String,
-    pub public_port: u16,
+    pub internal_address: String,
+    pub internal_port: u16,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, JsonSchema, ApiComponent)]
 pub struct EndpontsResp {
-    pub hanami: HanamiEndpontsResp,
-    pub bento: BentoEndpontsResp,
+    pub hanami: EndpointField,
+    pub bento: EndpointField,
 }

--- a/src/libs/rust/ainari_clients/src/checkpoint.rs
+++ b/src/libs/rust/ainari_clients/src/checkpoint.rs
@@ -22,15 +22,15 @@ use ainari_common::error::AinariError;
 use crate::prepare_client;
 
 pub async fn init_checkpoint(
-    bento_endpoint: &ainari_config::BentoEndpoints,
+    bento_endpoint: &ainari_config::Endpoint,
     token: &String,
     internal_api_key: &str,
     checkpoint_uuid: &Uuid,
     name: &str,
     insecure_client: bool,
 ) -> Result<CheckpointInternalResp, AinariError> {
-    let address = bento_endpoint.public_address.clone();
-    let port = bento_endpoint.public_port;
+    let address = bento_endpoint.internal_address.clone();
+    let port = bento_endpoint.internal_port;
     let https_connection = address.starts_with("https://");
     let client = prepare_client(https_connection, insecure_client);
     let address_complete = format!("{address}:{port}/v1alpha/checkpoint/internal");
@@ -93,14 +93,14 @@ pub async fn init_checkpoint(
 }
 
 pub async fn get_checkpoint(
-    bento_endpoint: &ainari_config::BentoEndpoints,
+    bento_endpoint: &ainari_config::Endpoint,
     token: &String,
     internal_api_key: &str,
     checkpoint_uuid: &Uuid,
     insecure_client: bool,
 ) -> Result<CheckpointInternalResp, AinariError> {
-    let address = bento_endpoint.public_address.clone();
-    let port = bento_endpoint.public_port;
+    let address = bento_endpoint.internal_address.clone();
+    let port = bento_endpoint.internal_port;
     let https_connection = address.starts_with("https://");
     let client = prepare_client(https_connection, insecure_client);
     let address_complete =

--- a/src/libs/rust/ainari_clients/src/dataset.rs
+++ b/src/libs/rust/ainari_clients/src/dataset.rs
@@ -22,15 +22,15 @@ use ainari_common::error::AinariError;
 use crate::prepare_client;
 
 pub async fn init_dataset(
-    bento_endpoint: &ainari_config::BentoEndpoints,
+    bento_endpoint: &ainari_config::Endpoint,
     token: &String,
     internal_api_key: &str,
     dataset_uuid: &Uuid,
     name: &str,
     insecure_client: bool,
 ) -> Result<DatasetInternalResp, AinariError> {
-    let address = bento_endpoint.public_address.clone();
-    let port = bento_endpoint.public_port;
+    let address = bento_endpoint.internal_address.clone();
+    let port = bento_endpoint.internal_port;
     let https_connection = address.starts_with("https://");
     let client = prepare_client(https_connection, insecure_client);
     let address_complete = format!("{address}:{port}/v1alpha/dataset/internal");
@@ -93,14 +93,14 @@ pub async fn init_dataset(
 }
 
 pub async fn get_dataset(
-    bento_endpoint: &ainari_config::BentoEndpoints,
+    bento_endpoint: &ainari_config::Endpoint,
     token: &String,
     internal_api_key: &str,
     dataset_uuid: &Uuid,
     insecure_client: bool,
 ) -> Result<DatasetInternalResp, AinariError> {
-    let address = bento_endpoint.public_address.clone();
-    let port = bento_endpoint.public_port;
+    let address = bento_endpoint.internal_address.clone();
+    let port = bento_endpoint.internal_port;
     let https_connection = address.starts_with("https://");
     let client = prepare_client(https_connection, insecure_client);
     let address_complete = format!("{address}:{port}/v1alpha/dataset/{dataset_uuid}/internal");

--- a/src/libs/rust/ainari_clients/src/endpoints.rs
+++ b/src/libs/rust/ainari_clients/src/endpoints.rs
@@ -66,13 +66,17 @@ pub async fn get_endpoints(
 
                     // converting
                     let endpoints = ainari_config::Endpoints {
-                        hanami: ainari_config::HanamiEndpoints {
+                        hanami: ainari_config::Endpoint {
                             public_address: deserialized.hanami.public_address,
                             public_port: deserialized.hanami.public_port,
+                            internal_address: deserialized.hanami.internal_address,
+                            internal_port: deserialized.hanami.internal_port,
                         },
-                        bento: ainari_config::BentoEndpoints {
+                        bento: ainari_config::Endpoint {
                             public_address: deserialized.bento.public_address,
                             public_port: deserialized.bento.public_port,
+                            internal_address: deserialized.bento.internal_address,
+                            internal_port: deserialized.bento.internal_port,
                         },
                     };
 

--- a/src/libs/rust/ainari_common/src/config.rs
+++ b/src/libs/rust/ainari_common/src/config.rs
@@ -26,21 +26,17 @@ fn default_miko_port() -> u16 {
 }
 
 #[derive(Debug, Deserialize, Default)]
-pub struct HanamiEndpoints {
+pub struct Endpoint {
     pub public_address: String,
     pub public_port: u16,
-}
-
-#[derive(Debug, Deserialize, Default)]
-pub struct BentoEndpoints {
-    pub public_address: String,
-    pub public_port: u16,
+    pub internal_address: String,
+    pub internal_port: u16,
 }
 
 #[derive(Debug, Deserialize, Default)]
 pub struct Endpoints {
-    pub hanami: HanamiEndpoints,
-    pub bento: BentoEndpoints,
+    pub hanami: Endpoint,
+    pub bento: Endpoint,
 }
 
 #[derive(Debug, Deserialize)]


### PR DESCRIPTION

## Pull Request

### Description
Because of incomplete testing, the recent update for the new endpoints was incomplete and broke the kubernetes setup. This was fixed now.

<!-- A concise description of the content of the pull-request -->

### Related Issues
- #709 
<!-- In context of which issues the changes of this pull request were created. -->

### How it was tested?

- extended ci-pipeline
- local k3s-test
<!-- What parts and how they were tested -->
