### PR TITLE
refactor(#723): bit better structure in omamori

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -317,13 +317,13 @@
         "line_number": 13
       }
     ],
-    "src/binaries/omamori/src/database/secret_table.rs": [
+    "src/binaries/omamori/src/database/simple_crypto_table.rs": [
       {
         "type": "Secret Keyword",
-        "filename": "src/binaries/omamori/src/database/secret_table.rs",
+        "filename": "src/binaries/omamori/src/database/simple_crypto_table.rs",
         "hashed_secret": "5f4e3119fee8ae4ee26d6d105deba7f89ccbafc4",
         "is_verified": false,
-        "line_number": 224
+        "line_number": 122
       }
     ],
     "testing/python_sdk_api/sdk_api_test.py": [
@@ -343,5 +343,5 @@
       }
     ]
   },
-  "generated_at": "2025-11-02T20:20:24Z"
+  "generated_at": "2025-11-02T21:42:07Z"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 #### API-Breaking
 
+- split "hanami" into a new "hanami", "sakura" and "torii"
 - added new component named "Miko", where the endpoints for tokens, users and projects moved to.
 - Sakura now uses the Miko to check provided token over a new client-connection
 - improved version-output 
@@ -20,6 +21,9 @@
 
 - new component "Miko" for authentication
 - new componentn "Bento" for storage
+- new component "Sakura", which contains the core of the previous "Hanami"
+- new component "Torii" as proxy to the sakura-hosts
+- new component "Omamori" with a very simple AES-crypto backend to store and download secrets
 - use shared storage in kubernetes-setup to share files between Bento and Sakura
 - the new Miko-component provides the addresses of all components
 
@@ -27,6 +31,10 @@
 
 - use context-object, which includes token, public-addresses and insecure-flag in one object, to make the sdk-functions smaller and cleaner
 - keys are internally handled as new object, to prevent them from being printed on the console by accident
+- Dockerfiles:
+    - split into multiple-files, where each build only its own binary and not all, to reduce the build-time in the CI
+    - base-images are pinned by a hash now
+    - switch from ubuntu to debian-slim as base image to reduce the size
 
 ### Fixed
 

--- a/src/binaries/omamori/src/api/http_endpoints/secret/create_secret_v1_0.rs
+++ b/src/binaries/omamori/src/api/http_endpoints/secret/create_secret_v1_0.rs
@@ -18,7 +18,6 @@ use apistos::api_operation;
 use uuid::Uuid;
 use validator::Validate;
 
-use crate::config;
 use crate::core::crypto_trait::CryptoModule;
 use crate::core::simple_crypto::SimpleCrypto;
 use crate::database::secret_table;
@@ -52,10 +51,9 @@ pub async fn create_secret(
     let secret_uuid = Uuid::new_v4();
 
     // encrypt the secret with the simple-crypto-module
-    let key_b64 = &config::CONFIG.simple_crypto.key_b64;
     let simple_crypto = SimpleCrypto::new();
-    let encrypted_secret = match simple_crypto.encrypt(&body.secret_payload, key_b64) {
-        Ok(encrypted_secret) => encrypted_secret,
+    match simple_crypto.store(&secret_uuid, &body.secret_payload) {
+        Ok(()) => {}
         Err(AinariError::Unauthorized(msg)) => {
             return Err(ErrorResponse::Unauthorized(msg));
         }
@@ -69,10 +67,10 @@ pub async fn create_secret(
     };
 
     // add new secret to datbase
-    match secret_table::add_new_secret(&secret_uuid, &body.name, &encrypted_secret, &context) {
+    match secret_table::add_new_secret(&secret_uuid, &body.name, &context) {
         Ok(_) => {}
         Err(e) => {
-            log::error!("Failed to add secret with ID '{secret_uuid}' to database.: {e}");
+            log::error!("Failed to add secret with UUID '{secret_uuid}' to database.: {e}");
             return Err(ErrorResponse::InternalError("".to_string()));
         }
     };
@@ -93,7 +91,7 @@ pub async fn create_secret(
         }
         Err(_) => {
             log::error!(
-                "Failed to get secret with ID '{secret_uuid}' from database, even the secret should exist"
+                "Failed to get secret with UUID '{secret_uuid}' from database, even the secret should exist"
             );
             return Err(ErrorResponse::InternalError("".to_string()));
         }

--- a/src/binaries/omamori/src/api/http_endpoints/secret/delete_secret_v1_0.rs
+++ b/src/binaries/omamori/src/api/http_endpoints/secret/delete_secret_v1_0.rs
@@ -17,11 +17,14 @@ use apistos::actix::NoContent;
 use apistos::api_operation;
 use uuid::Uuid;
 
+use crate::core::crypto_trait::CryptoModule;
+use crate::core::simple_crypto::SimpleCrypto;
 use crate::database::secret_table;
 
 use ainari_api::errors::ErrorResponse;
 use ainari_api_structs::user_context::UserContext;
 use ainari_common::enums;
+use ainari_common::error::AinariError;
 
 #[api_operation(
     tag = "secret",
@@ -38,15 +41,30 @@ pub async fn delete_secret(
 ) -> Result<NoContent, ErrorResponse> {
     // delete secret from database
     match secret_table::delete_secret(&secret_uuid, &context) {
-        Ok(_) => {
-            return Ok(NoContent);
-        }
+        Ok(_) => {}
         Err(enums::DbError::InternalError) => {
             return Err(ErrorResponse::InternalError("".to_string()));
         }
         Err(enums::DbError::NotFound) => {
-            let msg = format!("Secret with ID '{secret_uuid}' not found.");
+            let msg = format!("Secret with UUID '{secret_uuid}' not found.");
             return Err(ErrorResponse::NotFound(msg));
+        }
+    };
+
+    let simple_crypto = SimpleCrypto::new();
+    match simple_crypto.delete(&secret_uuid) {
+        Ok(_) => {
+            return Ok(NoContent);
+        }
+        Err(AinariError::Unauthorized(msg)) => {
+            return Err(ErrorResponse::Unauthorized(msg));
+        }
+        Err(AinariError::InvalidInput(msg)) => {
+            return Err(ErrorResponse::BadRequest(msg));
+        }
+        Err(AinariError::Error(msg)) => {
+            log::error!("{msg}");
+            return Err(ErrorResponse::InternalError("".to_string()));
         }
     };
 }

--- a/src/binaries/omamori/src/api/http_endpoints/secret/get_secret_payload_v1_0.rs
+++ b/src/binaries/omamori/src/api/http_endpoints/secret/get_secret_payload_v1_0.rs
@@ -17,7 +17,6 @@ use actix_web::web::Path;
 use apistos::api_operation;
 use uuid::Uuid;
 
-use crate::config;
 use crate::core::crypto_trait::CryptoModule;
 use crate::core::simple_crypto::SimpleCrypto;
 use crate::database::secret_table;
@@ -41,7 +40,7 @@ pub async fn get_secret_with_payload(
     secret_uuid: Path<Uuid>,
     context: UserContext,
 ) -> Result<Json<SecretWithPayloadResp>, ErrorResponse> {
-    let secret_data = match secret_table::get_secret(&secret_uuid, &context) {
+    let _ = match secret_table::get_secret(&secret_uuid, &context) {
         Ok(secret_data) => secret_data,
         Err(enums::DbError::InternalError) => {
             return Err(ErrorResponse::InternalError("".to_string()));
@@ -53,9 +52,8 @@ pub async fn get_secret_with_payload(
     };
 
     // decrypt the secret with the simple-crypto-module
-    let key_b64 = &config::CONFIG.simple_crypto.key_b64;
     let simple_crypto = SimpleCrypto::new();
-    let plaintext = match simple_crypto.decrypt(&secret_data.encrypted_secret, key_b64) {
+    let plaintext = match simple_crypto.retrieve(&secret_uuid) {
         Ok(plaintext) => plaintext,
         Err(AinariError::Unauthorized(msg)) => {
             return Err(ErrorResponse::Unauthorized(msg));

--- a/src/binaries/omamori/src/core/crypto_trait.rs
+++ b/src/binaries/omamori/src/core/crypto_trait.rs
@@ -12,12 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use uuid::Uuid;
+
 use ainari_common::error::AinariError;
 use ainari_common::secret::Secret;
 
 pub trait CryptoModule {
-    fn encrypt(&self, plaintext: &Secret, key_b64: &Secret) -> Result<String, AinariError>;
-    fn decrypt(&self, encrypted_secret_b64: &str, key_b64: &Secret) -> Result<Secret, AinariError>;
+    fn store(&self, secret_uuid: &Uuid, plaintext: &Secret) -> Result<(), AinariError>;
+    fn retrieve(&self, secret_uuid: &Uuid) -> Result<Secret, AinariError>;
+    fn delete(&self, secret_uuid: &Uuid) -> Result<(), AinariError>;
     #[allow(dead_code)]
     fn get_name(&self) -> String;
 }

--- a/src/binaries/omamori/src/core/simple_crypto.rs
+++ b/src/binaries/omamori/src/core/simple_crypto.rs
@@ -17,9 +17,14 @@ use aes_gcm::{Aes256Gcm, Nonce};
 use base64::Engine;
 use base64::engine::general_purpose::STANDARD;
 use rand::RngCore; // needed to use .encode() and .decode()
+use uuid::Uuid;
+
+use crate::config;
+use crate::database::simple_crypto_table;
 
 use super::crypto_trait::*;
 
+use ainari_common::enums;
 use ainari_common::error::AinariError;
 use ainari_common::secret::Secret;
 
@@ -37,32 +42,6 @@ impl SimpleCrypto {
             name: "simple_crypto".to_owned(),
         }
     }
-}
-
-fn decode_base64_key(key_b64: &Secret) -> Result<Vec<u8>, AinariError> {
-    // decode base64 key
-    let key_bytes = match STANDARD.decode(key_b64.reveal().as_bytes()) {
-        Ok(key_bytes) => key_bytes,
-        Err(_) => {
-            // HINT (kitsudaiki): do NOT use the error-message of the decode-function to avoid the risk
-            // of printing information of the key in the log-output
-            let msg = "Provided key is not a valid base64-encoded string.".to_string();
-            return Err(AinariError::InvalidInput(msg));
-        }
-    };
-    if key_bytes.len() != KEY_SIZE {
-        let msg = format!(
-            "Invalid key length: expected {}, got {}",
-            KEY_SIZE,
-            key_bytes.len()
-        );
-        return Err(AinariError::InvalidInput(msg));
-    }
-
-    Ok(key_bytes)
-}
-
-impl CryptoModule for SimpleCrypto {
     fn encrypt(&self, plaintext: &Secret, key_b64: &Secret) -> Result<String, AinariError> {
         let key_bytes = decode_base64_key(key_b64)?;
 
@@ -129,6 +108,77 @@ impl CryptoModule for SimpleCrypto {
             }
         };
         Ok(Secret::from(plaintext))
+    }
+}
+
+fn decode_base64_key(key_b64: &Secret) -> Result<Vec<u8>, AinariError> {
+    // decode base64 key
+    let key_bytes = match STANDARD.decode(key_b64.reveal().as_bytes()) {
+        Ok(key_bytes) => key_bytes,
+        Err(_) => {
+            // HINT (kitsudaiki): do NOT use the error-message of the decode-function to avoid the risk
+            // of printing information of the key in the log-output
+            let msg = "Provided key is not a valid base64-encoded string.".to_string();
+            return Err(AinariError::InvalidInput(msg));
+        }
+    };
+    if key_bytes.len() != KEY_SIZE {
+        let msg = format!(
+            "Invalid key length: expected {}, got {}",
+            KEY_SIZE,
+            key_bytes.len()
+        );
+        return Err(AinariError::InvalidInput(msg));
+    }
+
+    Ok(key_bytes)
+}
+
+impl CryptoModule for SimpleCrypto {
+    fn store(&self, secret_uuid: &Uuid, plaintext: &Secret) -> Result<(), AinariError> {
+        let key_b64 = &config::CONFIG.simple_crypto.key_b64;
+        let encrypted_secret = self.encrypt(plaintext, key_b64)?;
+
+        // add new secret to datbase
+        match simple_crypto_table::add_new_simple_crypto_data(secret_uuid, &encrypted_secret) {
+            Ok(_) => {}
+            Err(_) => {
+                let msg = format!(
+                    "Failed to add simple-crypto-secret with UUID '{secret_uuid}' to database."
+                );
+                return Err(AinariError::Error(msg));
+            }
+        };
+
+        Ok(())
+    }
+
+    fn retrieve(&self, secret_uuid: &Uuid) -> Result<Secret, AinariError> {
+        let secret_data = match simple_crypto_table::get_secret(secret_uuid) {
+            Ok(secret_data) => secret_data,
+            Err(enums::DbError::InternalError) => {
+                return Err(AinariError::Error("".to_string()));
+            }
+            Err(enums::DbError::NotFound) => {
+                let msg = format!("Secret with UUID '{secret_uuid}' not found.");
+                return Err(AinariError::InvalidInput(msg));
+            }
+        };
+
+        let key_b64 = &config::CONFIG.simple_crypto.key_b64;
+        self.decrypt(&secret_data.encrypted_secret, key_b64)
+    }
+
+    fn delete(&self, secret_uuid: &Uuid) -> Result<(), AinariError> {
+        // delete secret from database
+        match simple_crypto_table::delete_secret(secret_uuid) {
+            Ok(_) => Ok(()),
+            Err(enums::DbError::InternalError) => Err(AinariError::Error("".to_string())),
+            Err(enums::DbError::NotFound) => {
+                let msg = format!("Secret with UUID '{secret_uuid}' not found.");
+                Err(AinariError::InvalidInput(msg))
+            }
+        }
     }
 
     fn get_name(&self) -> String {

--- a/src/binaries/omamori/src/database/mod.rs
+++ b/src/binaries/omamori/src/database/mod.rs
@@ -14,6 +14,7 @@
 
 pub mod db_handle;
 pub mod secret_table;
+pub mod simple_crypto_table;
 
 pub fn init_database() -> Result<(), Box<dyn std::error::Error>> {
     // Initialize host-table
@@ -21,6 +22,15 @@ pub fn init_database() -> Result<(), Box<dyn std::error::Error>> {
         Ok(_) => log::info!("Initilaized secret-database-table"),
         Err(e) => {
             log::error!("Failed to initialize secret-database-table: {e}");
+            return Err(e);
+        }
+    };
+
+    // Initialize host-table
+    match simple_crypto_table::init_simple_crypto_table() {
+        Ok(_) => log::info!("Initilaized simple-crypto-database-table"),
+        Err(e) => {
+            log::error!("Failed to initialize simple-crypto-database-table: {e}");
             return Err(e);
         }
     };

--- a/src/binaries/omamori/src/database/secret_table.rs
+++ b/src/binaries/omamori/src/database/secret_table.rs
@@ -28,7 +28,6 @@ table! {
     secrets (uuid) {
         uuid -> Varchar,
         name -> Varchar,
-        encrypted_secret -> Varchar,
         owner_id -> Varchar,
         project_id -> Varchar,
         status -> Varchar,
@@ -46,7 +45,6 @@ table! {
 pub struct SecretEntry {
     pub uuid: String,
     pub name: String,
-    pub encrypted_secret: String,
     pub owner_id: String,
     pub project_id: String,
     pub status: String,
@@ -64,7 +62,6 @@ pub fn init_secret_table() -> Result<(), Box<dyn Error>> {
         "CREATE TABLE IF NOT EXISTS secrets (
         uuid VARCHAR(40) PRIMARY KEY,
         name VARCHAR(256),
-        encrypted_secret TEXT,
         owner_id VARCHAR(256),
         project_id VARCHAR(256),
         status VARCHAR(10),
@@ -80,16 +77,10 @@ pub fn init_secret_table() -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
-pub fn add_new_secret(
-    secret_uuid: &Uuid,
-    name: &str,
-    encrypted_secret: &str,
-    context: &UserContext,
-) -> QueryResult<usize> {
+pub fn add_new_secret(secret_uuid: &Uuid, name: &str, context: &UserContext) -> QueryResult<usize> {
     let secret = SecretEntry {
         uuid: secret_uuid.to_string().clone(),
         name: name.to_owned(),
-        encrypted_secret: encrypted_secret.to_owned(),
         owner_id: context.user_id.clone(),
         project_id: context.project_id.clone(),
         status: "ACTIVE".to_string(),
@@ -221,7 +212,6 @@ mod tests {
         let _ = init_secret_table();
         let uuid1 = Uuid::new_v4();
         let name = "test-secret".to_string();
-        let encrypted_secret = "just a dummy-secret".to_string();
 
         let project_id = "test-project".to_string();
         let owner_id = "test-user".to_string();
@@ -236,7 +226,6 @@ mod tests {
         let secret = SecretEntry {
             uuid: uuid1.to_string(),
             name: name.clone(),
-            encrypted_secret: encrypted_secret.clone(),
             owner_id: owner_id.clone(),
             project_id: project_id.clone(),
             status: "ACTIVE".to_string(),
@@ -255,7 +244,6 @@ mod tests {
             Ok(retrieved_secret) => {
                 assert_eq!(retrieved_secret.uuid, secret.uuid);
                 assert_eq!(retrieved_secret.name, secret.name);
-                assert_eq!(retrieved_secret.encrypted_secret, secret.encrypted_secret);
                 assert_eq!(retrieved_secret.owner_id, secret.owner_id);
                 assert_eq!(retrieved_secret.project_id, secret.project_id);
                 assert_eq!(retrieved_secret.status, secret.status);
@@ -279,7 +267,6 @@ mod tests {
         let uuid1 = Uuid::new_v4();
         let uuid2 = Uuid::new_v4();
         let name = "test-secret".to_string();
-        let encrypted_secret = "just a dummy-secret".to_string();
 
         let project_id = "test-project".to_string();
         let owner_id = "test-user".to_string();
@@ -294,7 +281,6 @@ mod tests {
         let secret1 = SecretEntry {
             uuid: uuid1.to_string(),
             name: name.clone(),
-            encrypted_secret: encrypted_secret.clone(),
             owner_id: owner_id.clone(),
             project_id: project_id.clone(),
             status: "ACTIVE".to_string(),
@@ -309,7 +295,6 @@ mod tests {
         let secret2 = SecretEntry {
             uuid: uuid2.to_string(),
             name: name.clone(),
-            encrypted_secret: encrypted_secret.clone(),
             owner_id: owner_id.clone(),
             project_id: project_id.clone(),
             status: "DELETED".to_string(),
@@ -338,7 +323,6 @@ mod tests {
         let _ = init_secret_table();
         let uuid1 = Uuid::new_v4();
         let name = "test-secret".to_string();
-        let encrypted_secret = "just a dummy-secret".to_string();
 
         let project_id = "test-project".to_string();
         let owner_id = "test-user".to_string();
@@ -353,7 +337,6 @@ mod tests {
         let secret = SecretEntry {
             uuid: uuid1.to_string(),
             name: name.clone(),
-            encrypted_secret: encrypted_secret.clone(),
             owner_id: owner_id.clone(),
             project_id: project_id.clone(),
             status: "ACTIVE".to_string(),
@@ -381,12 +364,10 @@ mod tests {
         let uuid2 = Uuid::new_v4();
         let uuid3 = Uuid::new_v4();
         let name = "test-secret".to_string();
-        let encrypted_secret = "just a dummy-secret".to_string();
 
         let secret1 = SecretEntry {
             uuid: uuid1.to_string(),
             name: name.clone(),
-            encrypted_secret: encrypted_secret.clone(),
             owner_id: "test-user-42".to_string(),
             project_id: "test_permissions_1".to_string(),
             status: "ACTIVE".to_string(),
@@ -401,7 +382,6 @@ mod tests {
         let secret2 = SecretEntry {
             uuid: uuid2.to_string(),
             name: name.clone(),
-            encrypted_secret: encrypted_secret.clone(),
             owner_id: "test-user-43".to_string(),
             project_id: "test_permissions_1".to_string(),
             status: "ACTIVE".to_string(),
@@ -416,7 +396,6 @@ mod tests {
         let secret3 = SecretEntry {
             uuid: uuid3.to_string(),
             name: name.clone(),
-            encrypted_secret: encrypted_secret.clone(),
             owner_id: "test-user-44".to_string(),
             project_id: "test_permissions_2".to_string(),
             status: "ACTIVE".to_string(),

--- a/src/binaries/omamori/src/database/simple_crypto_table.rs
+++ b/src/binaries/omamori/src/database/simple_crypto_table.rs
@@ -1,0 +1,193 @@
+// Copyright 2022 Tobias Anker <tobias.anker@kitsunemimi.moe>
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use diesel::connection::SimpleConnection;
+use diesel::prelude::*;
+use std::error::Error;
+use uuid::Uuid;
+
+use crate::database::db_handle;
+
+use ainari_common::enums;
+
+// Define the schema
+table! {
+    simple_crypto (secret_uuid) {
+        secret_uuid -> Varchar,
+        encrypted_secret -> Varchar,
+    }
+}
+
+#[derive(Insertable, Queryable, Selectable, Debug, PartialEq, Clone)]
+#[diesel(table_name = simple_crypto)]
+pub struct SimpleCryptoEntry {
+    pub secret_uuid: String,
+    pub encrypted_secret: String,
+}
+
+pub fn init_simple_crypto_table() -> Result<(), Box<dyn Error>> {
+    let mut conn = db_handle::DB_CONN.lock().expect("mutex poisoned");
+    conn.batch_execute(
+        "CREATE TABLE IF NOT EXISTS simple_crypto (
+        secret_uuid VARCHAR(40) PRIMARY KEY,
+        encrypted_secret TEXT
+    );",
+    )?;
+
+    Ok(())
+}
+
+pub fn add_new_simple_crypto_data(uuid: &Uuid, encrypted_secret: &str) -> QueryResult<usize> {
+    let secret = SimpleCryptoEntry {
+        secret_uuid: uuid.to_string().clone(),
+        encrypted_secret: encrypted_secret.to_owned(),
+    };
+
+    add_secret(&secret)
+}
+
+pub fn add_secret(secret: &SimpleCryptoEntry) -> QueryResult<usize> {
+    let mut conn = db_handle::DB_CONN.lock().expect("mutex poisoned");
+    use self::simple_crypto::dsl::*;
+    diesel::insert_into(simple_crypto)
+        .values(secret)
+        .execute(&mut *conn)
+}
+
+pub fn get_secret(uuid: &Uuid) -> Result<SimpleCryptoEntry, enums::DbError> {
+    let mut conn = db_handle::DB_CONN.lock().expect("mutex poisoned");
+    use self::simple_crypto::dsl::*;
+
+    let query = simple_crypto
+        .filter(secret_uuid.eq(uuid.to_string()))
+        .into_boxed();
+
+    match query
+        .select(SimpleCryptoEntry::as_select())
+        .first::<SimpleCryptoEntry>(&mut *conn)
+    {
+        Ok(secret) => Ok(secret),
+        Err(diesel::result::Error::NotFound) => Err(enums::DbError::NotFound),
+        Err(e) => {
+            log::error!("Database-error: {e:?}");
+            Err(enums::DbError::InternalError)
+        }
+    }
+}
+
+#[allow(dead_code)]
+pub fn list_simple_crypto() -> QueryResult<Vec<SimpleCryptoEntry>> {
+    let mut conn = db_handle::DB_CONN.lock().expect("mutex poisoned");
+    use self::simple_crypto::dsl::*;
+    simple_crypto.load::<SimpleCryptoEntry>(&mut *conn)
+}
+
+pub fn delete_secret(uuid: &Uuid) -> Result<(), enums::DbError> {
+    get_secret(uuid)?;
+
+    let mut conn = db_handle::DB_CONN.lock().expect("mutex poisoned");
+    use self::simple_crypto::dsl::*;
+    match diesel::delete(simple_crypto.filter(secret_uuid.eq(uuid.to_string()))).execute(&mut *conn)
+    {
+        Ok(_) => Ok(()),
+        Err(diesel::result::Error::NotFound) => Err(enums::DbError::NotFound),
+        Err(e) => {
+            log::error!("Database-error: {e:?}");
+            Err(enums::DbError::InternalError)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serial_test::serial;
+
+    #[test]
+    #[serial]
+    fn test_add_get_secret() {
+        let _ = init_simple_crypto_table();
+        let uuid1 = Uuid::new_v4();
+        let encrypted_secret = "just a dummy-secret".to_string();
+
+        let secret = SimpleCryptoEntry {
+            secret_uuid: uuid1.to_string(),
+            encrypted_secret: encrypted_secret.clone(),
+        };
+
+        let _ = delete_secret(&uuid1);
+
+        add_secret(&secret).unwrap();
+        match get_secret(&uuid1) {
+            Ok(retrieved_secret) => {
+                assert_eq!(retrieved_secret.secret_uuid, secret.secret_uuid);
+                assert_eq!(retrieved_secret.encrypted_secret, secret.encrypted_secret);
+            }
+            Err(_) => {
+                assert_eq!(true, false);
+            }
+        };
+
+        let _ = delete_secret(&uuid1);
+    }
+
+    #[test]
+    #[serial]
+    fn test_list_simple_crypto() {
+        let _ = init_simple_crypto_table();
+        let uuid1 = Uuid::new_v4();
+        let uuid2 = Uuid::new_v4();
+        let encrypted_secret = "just a dummy-secret".to_string();
+
+        let secret1 = SimpleCryptoEntry {
+            secret_uuid: uuid1.to_string(),
+            encrypted_secret: encrypted_secret.clone(),
+        };
+
+        let secret2 = SimpleCryptoEntry {
+            secret_uuid: uuid2.to_string(),
+            encrypted_secret: encrypted_secret.clone(),
+        };
+
+        let _ = delete_secret(&uuid1);
+        let _ = delete_secret(&uuid2);
+
+        add_secret(&secret1).unwrap();
+        add_secret(&secret2).unwrap();
+        let simple_crypto = list_simple_crypto().unwrap();
+        assert_eq!(simple_crypto.len(), 2);
+        let _ = delete_secret(&uuid1);
+        let _ = delete_secret(&uuid2);
+    }
+
+    #[test]
+    #[serial]
+    fn test_delete_secret() {
+        let _ = init_simple_crypto_table();
+        let uuid1 = Uuid::new_v4();
+        let encrypted_secret = "just a dummy-secret".to_string();
+
+        let secret = SimpleCryptoEntry {
+            secret_uuid: uuid1.to_string(),
+            encrypted_secret: encrypted_secret.clone(),
+        };
+
+        let _ = delete_secret(&uuid1);
+
+        add_secret(&secret).unwrap();
+        let _ = delete_secret(&uuid1);
+        let result = get_secret(&uuid1);
+        assert!(result.is_err());
+    }
+}


### PR DESCRIPTION

## Pull Request

### Description
Made the separation to the simple-crypto module cleaner and renamed the functions. Secret-payload is not stored in an additional crypto-module specific table. This makes later integration of OpenBao and other as backends more easily.

<!-- A concise description of the content of the pull-request -->

### Related Issues

- #723 
<!-- In context of which issues the changes of this pull request were created. -->

### How it was tested?

- manually test with CLI
- CI-pipeline
<!-- What parts and how they were tested -->
