### PR TITLE
feat(#834): add forecast timelength

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
     - quota-management was added to the admin-section of the dashboard
     - dataset list in the dashboard now prints the number of rows and columns
     - cluster list in the dashboard now prints the cluster adress
+- added forecast-length as new parameter for train-tasks (only via python-sdk at the moment)
 
 ### Changed
 
@@ -46,7 +47,8 @@
 - fixed broken version-output of the pre-build docker images
 - restart of hanami and sakura instance in regard of the cluster was now fixed to avoid broken cluster and hosts after restart
 - restarts of the same sakura-host doesn't result in duplications in hanami anymore
-
+- progress-bar in dashboard for multiple epochs is now calculated correctly
+- fixed number of output-values in case of int and float output-type
 
 ## v0.10.0
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,5 +24,5 @@ overflow-checks = true
 [profile.release]
 opt-level = 3
 lto = "fat"
-codegen-units = 1
+codegen-units = 8
 strip = true

--- a/src/binaries/sakura/src/api/http_endpoints/model/task/checkpoint_restore_task_v1_0.rs
+++ b/src/binaries/sakura/src/api/http_endpoints/model/task/checkpoint_restore_task_v1_0.rs
@@ -88,7 +88,7 @@ pub async fn checkpoint_restore_task(
         model_uuid: *model_uuid,
         name: body.name.clone(),
         info: TaskVariant::CheckpointRestore(info),
-        meta: TaskMeta::new(1, 1, 1),
+        meta: TaskMeta::new(1, 1, 1, 0),
     };
     super::add_task_to_model(task, &task_type, &context)?;
 

--- a/src/binaries/sakura/src/api/http_endpoints/model/task/checkpoint_save_task_v1_0.rs
+++ b/src/binaries/sakura/src/api/http_endpoints/model/task/checkpoint_save_task_v1_0.rs
@@ -89,7 +89,7 @@ pub async fn checkpoint_save_task(
         model_uuid: *model_uuid,
         name: body.name.clone(),
         info: TaskVariant::CheckpointSave(info),
-        meta: TaskMeta::new(1, 1, 1),
+        meta: TaskMeta::new(1, 1, 1, 0),
     };
     super::add_task_to_model(task, &task_type, &context)?;
 

--- a/src/binaries/sakura/src/api/http_endpoints/model/task/create_request_task_v1_0.rs
+++ b/src/binaries/sakura/src/api/http_endpoints/model/task/create_request_task_v1_0.rs
@@ -141,7 +141,7 @@ pub async fn create_request_task(
             model_uuid: *model_uuid,
             name: body.name.clone(),
             info: TaskVariant::Request(Box::new(info)),
-            meta: TaskMeta::new(number_of_cycles, 1, time_length),
+            meta: TaskMeta::new(number_of_cycles, 1, time_length, 0),
         };
         super::add_task_to_model(task, &task_type, &context)?;
 

--- a/src/binaries/sakura/src/api/http_endpoints/model/task/create_train_task_v1_0.rs
+++ b/src/binaries/sakura/src/api/http_endpoints/model/task/create_train_task_v1_0.rs
@@ -53,6 +53,7 @@ pub async fn create_train_task(
     let task_uuid = Uuid::new_v4();
     let task_type = TaskType::Train;
     let time_length = body.time_length.unwrap_or(1);
+    let forecast_length = body.forecast_length.unwrap_or(0);
     let mut number_of_cycles = u64::MAX;
 
     if time_length < 1 {
@@ -111,13 +112,18 @@ pub async fn create_train_task(
         }
 
         // handle the time-lenght-value
-        if number_of_cycles < time_length {
+        let cycle_length = time_length + forecast_length;
+        if number_of_cycles < cycle_length {
             let msg = format!(
-                "Time-length {time_length} is bigger than at least of of the seleced datasets."
+                "Time-length {cycle_length} is bigger than at least of of the seleced datasets."
             );
             return Err(ErrorResponse::BadRequest(msg));
         }
+        // TODO: seems not fully correct calculated
         number_of_cycles -= time_length - 1;
+        if forecast_length > 0 {
+            number_of_cycles /= forecast_length;
+        }
 
         // create new task
         let task = Task {
@@ -125,7 +131,12 @@ pub async fn create_train_task(
             model_uuid: *model_uuid,
             name: body.name.clone(),
             info: TaskVariant::Training(info),
-            meta: TaskMeta::new(number_of_cycles, body.number_of_epochs, time_length),
+            meta: TaskMeta::new(
+                number_of_cycles,
+                body.number_of_epochs,
+                time_length,
+                forecast_length,
+            ),
         };
         super::add_task_to_model(task, &task_type, &context)?;
 

--- a/src/binaries/sakura/src/core/blocks/core_block.rs
+++ b/src/binaries/sakura/src/core/blocks/core_block.rs
@@ -42,9 +42,8 @@ use super::super::processing::worker_queue::*;
 pub struct Synapse {
     /// The threshold value that must be exceeded for the synapse to activate.
     pub border: f32,
-    /// First synaptic weight value.
+    /// synaptic weight values.
     pub weight_1: f32,
-    /// Second synaptic weight value.
     pub weight_2: f32,
 
     /// Counter tracking how many times this synapse has been activated.

--- a/src/binaries/sakura/src/core/blocks/input_block.rs
+++ b/src/binaries/sakura/src/core/blocks/input_block.rs
@@ -144,14 +144,14 @@ impl InputBlock {
     /// * `input_size` - Size of the input data.
     /// * `offset` - Offset to apply to the input data.
     /// * `time_length` - Length of the time dimension of the input data.
-    /// * `allow_cration` - Whether to allow creation of new input links.
+    /// * `allow_creation` - Whether to allow creation of new input links.
     pub fn apply_input(
         &mut self,
         input_ptr: &[f32],
         input_size: usize,
         offset: usize,
         time_length: usize,
-        allow_cration: bool,
+        allow_creation: bool,
     ) {
         // resize links, if necessary
         let maximum_size = input_size * 2 * time_length;
@@ -162,7 +162,7 @@ impl InputBlock {
         let mut is_negative;
         let mut total_position;
 
-        if allow_cration {
+        if allow_creation {
             // update links
             for (i, val) in input_ptr.iter().enumerate().take(input_size) {
                 total_position = (offset + i) * 2;

--- a/src/binaries/sakura/src/core/model_interface.rs
+++ b/src/binaries/sakura/src/core/model_interface.rs
@@ -218,7 +218,6 @@ impl ModelInterface {
                 model_data_handler.get_output_buffer(&self.model_uuid, hexagon_name)?;
 
             let mut output_buffer = output_buffer_mutex.lock().expect("mutex poisoned");
-            data.resize(output_buffer.output_neurons.len(), 0.0f32);
             convert_output_to_buffer(data, &mut output_buffer);
         }
 

--- a/src/binaries/sakura/src/core/processing/finish_counter.rs
+++ b/src/binaries/sakura/src/core/processing/finish_counter.rs
@@ -21,25 +21,12 @@ use super::tasks::Task;
 /// within a specific cycle, and can trigger actions when the completion criteria are met.
 #[derive(Default, Debug)]
 pub struct FinishCounter {
-    /// Number of input tasks that have been compared in the current cycle.
     pub input_compare: usize,
-
-    /// Number of output tasks that have been compared in the current cycle.
     pub output_compare: usize,
-
-    /// The threshold number of task comparisons needed to consider the cycle finished.
     task_compare: usize,
-
-    /// Current count of completed tasks in the current cycle.
     counter: usize,
-
-    /// The cycle number we're expecting to complete.
     expected_cycle_number: u64,
-
-    /// Flag indicating whether this cycle has already been marked as finished.
     already_finished: bool,
-
-    /// Optional reference to the task that this counter is associated with.
     pub task: Option<Arc<Mutex<Task>>>,
 }
 

--- a/src/binaries/sakura/src/core/processing/output_buffer.rs
+++ b/src/binaries/sakura/src/core/processing/output_buffer.rs
@@ -229,7 +229,7 @@ impl OutputBuffer {
 /// Converts the output buffer's data to a flat buffer of f32 values.
 /// The conversion depends on the output type (plain, bool, int, or float).
 /// Returns the number of elements written to the buffer.
-pub fn convert_output_to_buffer(buffer: &mut [f32], output_buffer: &mut OutputBuffer) -> usize {
+pub fn convert_output_to_buffer(buffer: &mut Vec<f32>, output_buffer: &mut OutputBuffer) -> usize {
     output_buffer.already_finalized = false;
     match output_buffer.output_type {
         OutputType::PlainOutput => handle_plain_output(buffer, output_buffer),
@@ -259,7 +259,9 @@ pub fn convert_buffer_to_expected(
 
 /// Handles conversion of plain output type to a flat buffer.
 /// Copies the output values directly to the buffer.
-fn handle_plain_output(buffer: &mut [f32], output_buffer: &OutputBuffer) -> usize {
+fn handle_plain_output(buffer: &mut Vec<f32>, output_buffer: &OutputBuffer) -> usize {
+    buffer.resize(output_buffer.output_neurons.len(), 0.0f32);
+
     let number_of_outputs = min(buffer.len(), output_buffer.output_neurons.len());
 
     for (i, buffer) in buffer.iter_mut().enumerate().take(number_of_outputs) {
@@ -271,7 +273,9 @@ fn handle_plain_output(buffer: &mut [f32], output_buffer: &OutputBuffer) -> usiz
 
 /// Handles conversion of bool output type to a flat buffer.
 /// Converts output values to 0.0 or 1.0 based on a threshold of 0.5.
-fn handle_bool_output(buffer: &mut [f32], output_buffer: &OutputBuffer) -> usize {
+fn handle_bool_output(buffer: &mut Vec<f32>, output_buffer: &OutputBuffer) -> usize {
+    buffer.resize(output_buffer.output_neurons.len(), 0.0f32);
+
     let number_of_outputs = min(buffer.len(), output_buffer.output_neurons.len());
 
     for (i, buffer) in buffer.iter_mut().enumerate().take(number_of_outputs) {
@@ -283,15 +287,16 @@ fn handle_bool_output(buffer: &mut [f32], output_buffer: &OutputBuffer) -> usize
 
 /// Handles conversion of int output type to a flat buffer.
 /// Combines 64 neurons into a single integer value.
-fn handle_int_output(buffer: &mut [f32], output_buffer: &OutputBuffer) -> usize {
+fn handle_int_output(buffer: &mut Vec<f32>, output_buffer: &OutputBuffer) -> usize {
+    buffer.resize(output_buffer.output_neurons.len() / 64, 0.0f32);
     let number_of_outputs = min(buffer.len(), output_buffer.output_neurons.len() / 64);
 
     for (i, buffer) in buffer.iter_mut().enumerate().take(number_of_outputs) {
-        let mut val: u32 = 0;
+        let mut val: u64 = 0;
 
         for offset in 0..64 {
             let neuron = &output_buffer.output_neurons[i * 64 + offset];
-            val = (val << 1) | ((neuron.output_value >= 0.5) as u32);
+            val = (val << 1) | ((neuron.output_value >= 0.50) as u64);
         }
 
         *buffer = val as f32;
@@ -302,7 +307,8 @@ fn handle_int_output(buffer: &mut [f32], output_buffer: &OutputBuffer) -> usize 
 
 /// Handles conversion of float output type to a flat buffer.
 /// Combines 32 neurons into a single float value using bit packing.
-fn handle_float_output(buffer: &mut [f32], output_buffer: &OutputBuffer) -> usize {
+fn handle_float_output(buffer: &mut Vec<f32>, output_buffer: &OutputBuffer) -> usize {
+    buffer.resize(output_buffer.output_neurons.len() / 32, 0.0f32);
     let number_of_outputs = min(buffer.len(), output_buffer.output_neurons.len() / 32);
 
     for (i, buffer) in buffer.iter_mut().enumerate().take(number_of_outputs) {

--- a/src/binaries/sakura/src/core/processing/task_queue.rs
+++ b/src/binaries/sakura/src/core/processing/task_queue.rs
@@ -122,14 +122,14 @@ mod tests {
             model_uuid,
             name: "task1".to_string(),
             info: TaskVariant::CheckpointSave(info1),
-            meta: TaskMeta::new(1, 1, 1),
+            meta: TaskMeta::new(1, 1, 1, 0),
         };
         let task2 = Task {
             uuid: uuid2,
             model_uuid,
             name: "task2".to_string(),
             info: TaskVariant::CheckpointSave(info2),
-            meta: TaskMeta::new(1, 1, 1),
+            meta: TaskMeta::new(1, 1, 1, 0),
         };
 
         queue.add(task1);

--- a/src/binaries/sakura/src/core/processing/tasks.rs
+++ b/src/binaries/sakura/src/core/processing/tasks.rs
@@ -100,8 +100,10 @@ pub struct TaskMeta {
     pub number_of_finished_cycles: u64,
     /// Number of epochs completed so far.
     pub number_of_finished_epochs: u64,
-    /// Time length for the task in seconds.
+    /// Time length for the task in input-values.
     pub time_length: u64,
+    /// Forecast length for the task in input-values.
+    pub forecast_length: u64,
 
     /// Counter for tracking task cycles across all epochs.
     pub task_cycle_counter: u64,
@@ -124,13 +126,19 @@ impl TaskMeta {
     /// # Returns
     ///
     /// A new TaskMeta instance initialized with the given parameters.
-    pub fn new(number_of_cycler_per_epoch: u64, number_of_epochs: u64, time_length: u64) -> Self {
+    pub fn new(
+        number_of_cycler_per_epoch: u64,
+        number_of_epochs: u64,
+        time_length: u64,
+        forecast_length: u64,
+    ) -> Self {
         Self {
             number_of_cycles: number_of_cycler_per_epoch,
             number_of_epochs,
             number_of_finished_cycles: 0,
             number_of_finished_epochs: 0,
             time_length,
+            forecast_length,
 
             task_cycle_counter: 0,
 
@@ -300,7 +308,7 @@ impl Task {
 
         // update and check cycle- and epoch-counter
         self.meta.number_of_finished_cycles += 1;
-        if self.meta.number_of_finished_cycles == self.meta.number_of_cycles {
+        if self.meta.number_of_finished_cycles >= self.meta.number_of_cycles {
             self.meta.number_of_finished_epochs += 1;
             if self.meta.number_of_finished_epochs == self.meta.number_of_epochs {
                 self.meta.is_finished = true;
@@ -407,6 +415,7 @@ fn run_train_task_cycle(
             file_handle,
             meta.number_of_finished_cycles,
             meta.time_length,
+            meta.forecast_length,
         ) {
             Ok(()) => {}
             Err(AinariError::Unauthorized(msg)) => {
@@ -432,10 +441,8 @@ fn run_train_task_cycle(
             model_uuid,
             hexagon_name,
             file_handle,
-            meta.number_of_finished_cycles,
-            meta.time_length,
+            meta,
             &WorkerTaskType::Train,
-            meta.task_cycle_counter,
         ) {
             Ok(()) => {}
             Err(AinariError::Unauthorized(msg)) => {
@@ -495,10 +502,8 @@ fn run_request_task_cycle(
             model_uuid,
             hexagon_name,
             file_handle,
-            meta.number_of_finished_cycles,
-            meta.time_length,
+            meta,
             &WorkerTaskType::Process,
-            meta.number_of_finished_cycles,
         ) {
             Ok(()) => {}
             Err(AinariError::Unauthorized(msg)) => {
@@ -581,10 +586,8 @@ pub fn apply_plain_input(
 /// * `model_uuid` - Unique identifier for the model
 /// * `hexagon_name` - Name of the hexagon (input block) to apply data to
 /// * `file_handle` - Mutable reference to the dataset file handle
-/// * `cycle_count` - Current cycle count
-/// * `time_length` - Length of time for the input data
+/// * `meta` - Task-meta construct with cycle-counter and so on
 /// * `task_type` - Type of worker task (Train or Process)
-/// * `task_cycle_counter` - Counter for the task cycle
 ///
 /// # Returns
 ///
@@ -593,10 +596,8 @@ fn apply_dataset_to_input(
     model_uuid: &Uuid,
     hexagon_name: &String,
     file_handle: &mut DataSetFileReadHandle,
-    cycle_count: u64,
-    time_length: u64,
+    meta: &TaskMeta,
     task_type: &WorkerTaskType,
-    task_cycle_counter: u64,
 ) -> Result<(), AinariError> {
     // get input-block
     let model_handler = CLUSTER_HANDLER.read().expect("mutex poisoned");
@@ -605,17 +606,24 @@ fn apply_dataset_to_input(
 
     let mut input_block = input_block_mutex.lock().expect("mutex poisoned");
 
+    let offset = if meta.forecast_length == 0 {
+        meta.number_of_finished_cycles
+    } else {
+        meta.number_of_finished_cycles * meta.forecast_length
+    };
+
     // fill input with data from dataset
     let mut pos_counter: usize = 0;
-    for time_point in 0..time_length {
-        let (input_ptr, input_size) =
-            file_handle.get_data_from_file(&(cycle_count + time_point))?;
+    for cycle_internal_time_point in 0..meta.time_length {
+        let row_number = offset + cycle_internal_time_point;
+        let (input_ptr, input_size) = file_handle.get_data_from_file(&row_number)?;
         let allow_creation = *task_type == WorkerTaskType::Train;
+
         input_block.apply_input(
             input_ptr,
             input_size as usize,
             pos_counter,
-            time_length as usize,
+            meta.time_length as usize,
             allow_creation,
         );
 
@@ -627,7 +635,7 @@ fn apply_dataset_to_input(
     let worker_task = WorkerTask {
         task_type: task_type.clone(),
         block: Arc::clone(&input_block_mutex) as Arc<Mutex<dyn Block>>,
-        cycle_number: task_cycle_counter,
+        cycle_number: meta.task_cycle_counter,
     };
     worker_queue.add(worker_task);
 
@@ -677,6 +685,7 @@ pub fn apply_expected(
 /// * `file_handle` - Mutable reference to the dataset file handle
 /// * `cycle_count` - Current cycle count
 /// * `time_length` - Length of time for the input data
+/// * `forecast_length` - Length of time for the output data
 ///
 /// # Returns
 ///
@@ -687,11 +696,32 @@ fn apply_dataset_to_expected(
     file_handle: &mut DataSetFileReadHandle,
     cycle_count: u64,
     time_length: u64,
+    forecast_length: u64,
 ) -> Result<(), AinariError> {
-    let (input_ptr, input_size) =
-        file_handle.get_data_from_file(&(cycle_count + time_length - 1))?;
+    let model_handler = CLUSTER_HANDLER.read().expect("mutex poisoned");
+    let output_buffer_mutex = model_handler.get_output_buffer(model_uuid, hexagon_name)?;
 
-    apply_expected(model_uuid, hexagon_name, input_ptr, input_size)?;
+    let mut output_buffer = output_buffer_mutex.lock().expect("mutex poisoned");
+    output_buffer.reset_output();
+
+    if forecast_length == 0 {
+        let (input_ptr, input_size) =
+            file_handle.get_data_from_file(&(cycle_count + time_length - 1))?;
+        convert_buffer_to_expected(&mut output_buffer, input_ptr, input_size);
+    } else {
+        // fill input with data from dataset
+        let (_, row_size) = file_handle.get_data_from_file(&(cycle_count + time_length))?;
+        let mut input_buffer = vec![0.0f32; (row_size * forecast_length) as usize];
+        for cycle_internal_time_point in 0..forecast_length {
+            let row_number =
+                (cycle_count * forecast_length) + time_length + cycle_internal_time_point;
+            let (input_ptr, input_size) = file_handle.get_data_from_file(&row_number)?;
+            let start = (cycle_internal_time_point * row_size) as usize;
+            input_buffer[start..start + input_size as usize].copy_from_slice(input_ptr);
+        }
+
+        convert_buffer_to_expected(&mut output_buffer, &input_buffer, input_buffer.len() as u64);
+    }
 
     Ok(())
 }

--- a/src/dashboard/app/src/components/workload/task/progress_bar.vue
+++ b/src/dashboard/app/src/components/workload/task/progress_bar.vue
@@ -76,8 +76,8 @@ export default defineComponent({
 
                 // calculate current progress
                 let state =
-                    (100 / task_response.data.total_number_of_cycles) *
-                    task_response.data.total_number_of_epochs;
+                    (100 / (task_response.data.total_number_of_cycles *
+                    task_response.data.total_number_of_epochs));
                 state *=
                     task_response.data.current_epoch *
                         task_response.data.total_number_of_cycles +

--- a/src/libs/rust/ainari_api_structs/src/task_structs.rs
+++ b/src/libs/rust/ainari_api_structs/src/task_structs.rs
@@ -117,6 +117,8 @@ pub struct TaskCreateTrainReq {
     pub number_of_epochs: u64,
     #[validate(range(min = 1, max = 100000000))]
     pub time_length: Option<u64>,
+    #[validate(range(min = 0, max = 100000000))]
+    pub forecast_length: Option<u64>,
     #[validate(nested, length(min = 1))]
     pub inputs: Vec<TaskDatasetLink>,
     #[validate(nested, length(min = 1))]

--- a/src/sdk/python/ainari_sdk/ainari_sdk/dataset.py
+++ b/src/sdk/python/ainari_sdk/ainari_sdk/dataset.py
@@ -70,7 +70,7 @@ def check_dataset(context: AccessContext,
 def upload_mnist_files(context: AccessContext,
                        name: str,
                        input_file_path: str,
-                       label_file_path: str) -> str:
+                       label_file_path: str) -> dict:
     path = f"/v1alpha/dataset/mnist/{name}"
     files = [input_file_path, label_file_path]
 
@@ -82,7 +82,7 @@ def upload_mnist_files(context: AccessContext,
 
 def upload_csv_files(context: AccessContext,
                      name: str,
-                     input_file_path: str) -> str:
+                     input_file_path: str) -> dict:
     path = f"/v1alpha/dataset/csv/{name}"
     files = [input_file_path]
 

--- a/src/sdk/python/ainari_sdk/ainari_sdk/task.py
+++ b/src/sdk/python/ainari_sdk/ainari_sdk/task.py
@@ -25,7 +25,8 @@ def create_train_task(context: AccessContext,
                       inputs: list,
                       outputs: list,
                       number_of_epochs: int = 1,
-                      timeLength: int = 1) -> dict:
+                      time_length: int = 1,
+                      forecast_length: int = 0) -> dict:
     address = f"{context.torii_base_address}:{torii_port}"
     print(f"address: {address}")
     path = f"/v1alpha/model/{model_uuid}/task/train"
@@ -34,7 +35,8 @@ def create_train_task(context: AccessContext,
         "number_of_epochs": number_of_epochs,
         "inputs": inputs,
         "outputs": outputs,
-        "time_length": timeLength,
+        "time_length": time_length,
+        "forecast_length": forecast_length,
     }
     return ainari_request.send_post_request(context,
                                             address,

--- a/testing/python_sdk_api/measure_tests.py
+++ b/testing/python_sdk_api/measure_tests.py
@@ -16,10 +16,10 @@
 
 import matplotlib
 import matplotlib.pyplot as plt
-from ainari_sdk import ainari_token
 from ainari_sdk import model
 from ainari_sdk import dataset
 from ainari_sdk import task
+from ainari_sdk import login
 import configparser
 import urllib3
 import time
@@ -54,7 +54,7 @@ matplotlib.use('Qt5Agg')
 config = configparser.ConfigParser()
 config.read('/etc/ainari/hanami_testing.conf')
 
-address = config["connection"]["address"]
+miko_address = config["connection"]["miko_address"]
 test_user_id = config["connection"]["test_user"]
 test_user_pw = config["connection"]["test_passphrase"]
 
@@ -84,17 +84,19 @@ template_name = "dynamic"
 request_dataset_name = "request_test_dataset"
 train_dataset_name = "train_test_dataset"
 
-token = ainari_token.request_token(address, test_user_id, test_user_pw, False)
+context = login.request_context(miko_address, test_user_id, test_user_pw, False)
+context.verify_connection = False
+print(context)
 
 # initial cleanup for the case of leftovers from previous run
-dataset.delete_all_datasets(token, address, False)
-model.delete_all_model(token, address, False)
+dataset.delete_all_datasets(context)
+model.delete_all_model(context)
 
 # update dataset
 train_dataset_uuid = dataset.upload_csv_files(
-    token, address, train_dataset_name, train_inputs_file, False)["uuid"]
+    context, train_dataset_name, train_inputs_file)["uuid"]
 request_dataset_uuid = dataset.upload_csv_files(
-    token, address, request_dataset_name, request_inputs_file, False)["uuid"]
+    context, request_dataset_name, request_inputs_file)["uuid"]
 
 # define relations between data and model
 train_inputs = [
@@ -128,25 +130,28 @@ request_outputs = [
 ]
 
 replicas = 5
-model_uuids = [""] * 10
-task_uuids = [""] * 10
+model_uuids = [""] * replicas
+torii_ports = [0] * replicas
+task_uuids = [""] * replicas
 flattened_list = [0.0] * 1750
 
 # create all model
 for x in range(replicas):
-    model_uuids[x] = model.create_model(
-        token, address, model_name + str(x), model_template, False)["uuid"]
+    model_resp = model.create_model(context,  model_name + str(x), model_template)
+    model_uuids[x] = model_resp["uuid"]
+    torii_ports[x] = model_resp["torii_port"]
+
 
 # train
 for x in range(replicas):
     print("train replica: ", x)
     print('\n')
     task_uuids[x] = task.create_train_task(
-        token, address, generic_task_name, model_uuids[x], train_inputs, train_outputs, 200, 20, False)["uuid"]
+        context, torii_ports[x], generic_task_name, model_uuids[x], train_inputs, train_outputs, 200, 20)["uuid"]
     finished = False
     while not finished:
         time.sleep(1)
-        result = task.get_task(token, address, task_uuids[x], model_uuids[x], False)
+        result = task.get_task(context, torii_ports[x], task_uuids[x], model_uuids[x])
         # print(json.dumps(result, indent=4))
 
         finished = result["state"] == "Finished" or result["state"] == "Error"
@@ -162,6 +167,8 @@ for x in range(replicas):
     
 # test
 for x in range(replicas):
+    print("==================================================")
+
     print("test replica: ", x)
     with open(request_inputs_file, mode='r') as file:
         reader = csv.reader(file)
@@ -180,14 +187,14 @@ for x in range(replicas):
             inputs = dict()
             inputs["test_input"] = values
 
-            output_values = model.request(token, address, model_uuids[x], inputs, output_names, False)
+            output_values = model.request(context, torii_ports[x], model_uuids[x], inputs, output_names)
             out_val = json.dumps(output_values["outputs"]["test_output"][0], indent=4)
             flattened_list[index] += float(out_val)
 
 # delete everything again
 for x in range(replicas):
-    model.delete_model(token, address, model_uuids[x], False)
-dataset.delete_dataset(token, address, train_dataset_uuid, False)
+    model.delete_model(context, model_uuids[x])
+dataset.delete_dataset(context, train_dataset_uuid)
 
 # update result
 for r in range(len(flattened_list)):


### PR DESCRIPTION


## Pull Request

### Description

While testing bigger examples with weather-data, a new forecast time-length was introduces, to test prediction of the next 24 hours.

<!-- A concise description of the content of the pull-request -->

### Related Issues

- #834 
<!-- In context of which issues the changes of this pull request were created. -->

### How it was tested?

- sdk-api-test
- other tests in context of the related issue
<!-- What parts and how they were tested -->
