### PR TITLE
fix: fixed handling of input of tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - support other namespaces thand "default"
 - support for multiple sakura instances
 - validation for task-input to avoid a mismatch between given input and the model
+- validation for task-input to avoid a mismatch between given input and the dataset
 - dashboard:
     - added error-popups
     - validation of input-fields and error-message for invalid inputs

--- a/src/binaries/sakura/src/api/http_endpoints/model/task/mod.rs
+++ b/src/binaries/sakura/src/api/http_endpoints/model/task/mod.rs
@@ -306,6 +306,15 @@ async fn handle_input(
     .await
     .map_err(map_ainari_error_to_api_response)?;
 
+    // check if requested column even exist in the dataset
+    if !dataset_resp.column_names.contains(&input.dataset_column) {
+        let msg = format!(
+            "Dataset-column with name '{}' doesn't exist in dataset with UUID '{}'",
+            input.dataset_column, input.dataset_uuid
+        );
+        return Err(ErrorResponse::BadRequest(msg));
+    }
+
     // create temp-file-paths
     let local_file_path = format!("{}/{}", temp_dir, dataset_resp.uuid);
     let local_encrypted_file_path = format!("{local_file_path}_encrypted");


### PR DESCRIPTION

## Pull Request

### Description
When provided invalid column-names for the tasks,
they were not checked against the dataset. This missing check was now added.
<!-- A concise description of the content of the pull-request -->

### Related Issues

- #831

<!-- In context of which issues the changes of this pull request were created. -->

### How it was tested?

- tried to create a task in non-existing column-names
<!-- What parts and how they were tested -->
