### PR TITLE
fix: fix clippy in CI again

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -36,7 +36,8 @@ jobs:
         name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y protobuf-compiler
+          sudo apt-get install -y protobuf-compiler gcc ssh curl pkg-config libssl-dev libsqlite3-dev
+          sudo curl https://sh.rustup.rs -sSf | sh -s -- -y
       -
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
       -

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -119,15 +119,19 @@ jobs:
       FORCE_COLOR: 1
     steps:
       -
-        uses: earthly/actions-setup@b81a8e082d9fae6174210cfc6e54bd2feb124d94
-        with:
-          version: "latest"
+        name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y git python3 python3-venv python3-pip
       -
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
       -
         name: Run check
-        run: earthly --ci +secret-scan
-    
+        run: |
+          python3 -m venv venv
+          source venv/bin/activate
+          pip3 install detect-secrets
+          git ls-files -z | xargs -0 detect-secrets-hook --baseline .secrets.baseline
 
 
   build_python_package:

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -91,6 +91,10 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
+      "path": "detect_secrets.filters.common.is_baseline_file",
+      "filename": ".secrets.baseline"
+    },
+    {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
       "min_level": 2
     },
@@ -129,7 +133,7 @@
         "filename": ".github/workflows/build_test.yml",
         "hashed_secret": "f8c9ca2243c245951407ec16a1918a5ec6a070b4",
         "is_verified": false,
-        "line_number": 409
+        "line_number": 414
       }
     ],
     ".vscode/launch.json": [
@@ -590,5 +594,5 @@
       }
     ]
   },
-  "generated_at": "2026-03-24T11:34:22Z"
+  "generated_at": "2026-04-23T16:41:57Z"
 }

--- a/Earthfile
+++ b/Earthfile
@@ -57,6 +57,7 @@ secret-scan:
     ENV PATH="/code/check_env/bin:$PATH"
     RUN pip3 install detect-secrets
     COPY . .
+    COPY .secrets.baseline .secrets.baseline
     RUN git ls-files -z | xargs -0 detect-secrets-hook --baseline .secrets.baseline
 
 

--- a/Earthfile
+++ b/Earthfile
@@ -50,17 +50,6 @@ ansible-lint:
     RUN ansible-lint deploy/ansible/ainari
 
 
-secret-scan:
-    RUN apt-get update && \
-        apt-get install -y python3 python3-pip git python3-venv && \
-        python3 -m venv check_env
-    ENV PATH="/code/check_env/bin:$PATH"
-    RUN pip3 install detect-secrets
-    COPY . .
-    COPY .secrets.baseline .secrets.baseline
-    RUN git ls-files -z | xargs -0 detect-secrets-hook --baseline .secrets.baseline
-
-
 prepare-build-dependencies:
     # install dependencies
     RUN apt-get update && \


### PR DESCRIPTION

## Pull Request

### Description
Strangely the last fix for the clippy-run
in the CI, was successful before the merge,
but failed after the merge. This time the
clippy-verison in the CI was updated to the
newest version to fix the problem.

Also had to fix the secret-scan.

<!-- A concise description of the content of the pull-request -->

### Related Issues

- #564

<!-- In context of which issues the changes of this pull request were created. -->

### How it was tested?

- CI-pipeline
<!-- What parts and how they were tested -->
